### PR TITLE
alerts: enable Grafana Alerts dashboard (9578) and add hub alert rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Agent Notes (GrafanaLocal / central-observability-hub-stack)
+
+These notes are local instructions for coding agents working in this repo.
+
+## Principles
+
+- **GitOps first**: Treat this repo as the source of truth. Avoid in-cluster hotfixes that will drift and be reverted by ArgoCD self-heal.
+- **Small, reviewable diffs**: Prefer focused PRs with clear intent and post-merge verification steps.
+- **Docs must match reality**: If you change any operational behavior, update the relevant docs in the same PR.
+
+## Where Things Live
+
+- ArgoCD applications: `argocd/applications/*.yaml`
+- Helm values: `helm/*.yaml`
+- In-repo dashboards: `dashboards/*.json` (mounted via ConfigMap from `dashboards/kustomization.yaml`)
+- Grafana provisioning (datasources + gnet dashboards + init patches): `helm/grafana-values.yaml`
+- Prometheus config + alert rules: `helm/prometheus-values.yaml` (`serverFiles.prometheus.yml`, `serverFiles.alerting_rules.yml`)
+
+## Grafana Dashboard Provisioning Gotchas
+
+- Datasource UIDs are fixed to avoid import prompts:
+  - Prometheus: `uid: prometheus`
+  - Loki: `uid: loki`
+  - Tempo: `uid: tempo`
+- Some upstream gnet dashboards require patching for file provisioning:
+  - duplicate dashboard UID collisions (Grafana rejects duplicates)
+  - Prometheus placeholders like `${DS_PROMETHEUS}` (file provisioning does not resolve `__inputs`)
+  - Loki dashboards shipping PromQL-like variable queries that get sent to Loki (LogQL parse error)
+  - These are patched in an initContainer in `helm/grafana-values.yaml`
+
+## Prometheus Scraping (OKE)
+
+- kubelet/cAdvisor scraping uses the apiserver proxy path (`/api/v1/nodes/<node>/proxy/...`) and requires RBAC `nodes/proxy`.
+- This repo adds `nodes/proxy` RBAC via `extraManifests` in `helm/prometheus-values.yaml`.
+
+## Tracing (Real Data)
+
+- `ingress-nginx` OpenTelemetry is enabled in `helm/nginx-ingress-values.yaml`.
+- The collector is deployed via ArgoCD app `argocd/applications/otel-collector.yaml` with values `helm/otel-collector-values.yaml`.
+- Collector image must be fully-qualified on OKE/CRI-O (short-name enforcement).
+
+## Alerting
+
+- Prometheus alert rules are defined in `helm/prometheus-values.yaml` under `serverFiles.alerting_rules.yml`.
+- Prefer stable metric sources:
+  - use kube-state-metrics for workload/pod readiness
+  - avoid alerts that depend on scrape-target `job=` names unless the scrape config guarantees them
+- For multi-cluster rules, always filter by `cluster="..."` to avoid mixing hub vs spokes.
+
+## PR Process (Repo Convention)
+
+- Always leave a PR comment before merging that includes:
+  - what caused the issue/change request
+  - root cause
+  - what was changed and why
+  - post-merge verification steps
+- If a PR fixes a GitHub issue, include `Closes #NN` in the PR description (or commit message) so it auto-closes on merge.
+
+## Quick Verification Checklist (Post-Change)
+
+- `kubectl -n argocd get applications` shows expected apps Healthy/Synced (or known/acceptable drift only).
+- Grafana dashboards load (especially provisioned Loki/Tempo dashboards if touched).
+- Prometheus targets:
+  - `kubernetes-nodes-cadvisor` is `UP`
+  - alert rules are loaded and evaluating
+- Tempo spans increment after ingress requests (PromQL): `sum(increase(tempo_distributor_spans_received_total[5m]))`
+

--- a/helm/grafana-values.yaml
+++ b/helm/grafana-values.yaml
@@ -295,3 +295,8 @@ dashboards:
       gnetId: 23242
       revision: latest
       datasource: Tempo
+    alerts-dashboard:
+      # Alerting overview dashboard (requires Prometheus alerts/rules to be present).
+      gnetId: 9578
+      revision: latest
+      datasource: Prometheus

--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -534,7 +534,7 @@ serverFiles:
 
           # 2. Hub Infrastructure: OKE Storage
           - alert: OKEStorageWarning
-            expr: (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes) * 100 < 15
+            expr: (kubelet_volume_stats_available_bytes{cluster="oke-hub"} / kubelet_volume_stats_capacity_bytes{cluster="oke-hub"}) * 100 < 15
             for: 5m
             labels:
               severity: warning
@@ -544,23 +544,226 @@ serverFiles:
 
           # 3. GitOps Heartbeat: Argo CD Controller
           - alert: ArgoCDControllerDown
-            expr: up{job="argocd-application-controller-metrics"} == 0
+            # Prefer kube-state-metrics over scrape-target job labels (more stable across scrape config changes)
+            expr: kube_statefulset_status_replicas_ready{namespace="argocd",statefulset="argocd-application-controller",cluster="oke-hub"} < 1
             for: 2m
             labels:
               severity: critical
             annotations:
               summary: "ArgoCD Monitoring Down"
-              description: "The ArgoCD application-controller is not reporting metrics."
+              description: "ArgoCD application-controller is not Ready (StatefulSet argocd/argocd-application-controller)."
 
           # 4. GitOps Health: Application Status
           - alert: ArgoCDApplicationDegraded
-            expr: argocd_app_info{health_status="Degraded"} == 1
+            expr: argocd_app_info{health_status="Degraded",cluster="oke-hub"} == 1
             for: 5m
             labels:
               severity: critical
             annotations:
               summary: "GitOps Application Degraded"
               description: "Application {{ $labels.name }} in project {{ $labels.project }} is in a failed state."
+
+      # ──────────────────────────────────────────────
+      # Tier 1: OKE Hub Cluster (oke-hub)
+      # Metrics are scraped locally; filter with cluster="oke-hub"
+      # ──────────────────────────────────────────────
+      - name: HubNodeAlerts
+        rules:
+          - alert: HubNodeHighCPU
+            expr: |
+              (
+                1 - avg by (service, cluster) (rate(node_cpu_seconds_total{mode="idle", cluster="oke-hub"}[5m]))
+              ) * 100 > 85
+            for: 10m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub node CPU > 85% for 10m"
+              description: "Node {{ $labels.service }} CPU usage is {{ $value | printf \"%.1f\" }}%."
+
+          - alert: HubNodeHighMemory
+            expr: |
+              (
+                1 - (node_memory_MemAvailable_bytes{cluster="oke-hub"} / node_memory_MemTotal_bytes{cluster="oke-hub"})
+              ) * 100 > 85
+            for: 10m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub node memory > 85% for 10m"
+              description: "Node {{ $labels.service }} memory usage is {{ $value | printf \"%.1f\" }}%."
+
+          - alert: HubNodeDiskPressure
+            expr: |
+              (
+                1 - (node_filesystem_avail_bytes{cluster="oke-hub", mountpoint="/", fstype!="tmpfs"} / node_filesystem_size_bytes{cluster="oke-hub", mountpoint="/", fstype!="tmpfs"})
+              ) * 100 > 85
+            for: 10m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub node disk > 85% full"
+              description: "Node {{ $labels.service }} root disk usage is {{ $value | printf \"%.1f\" }}%."
+
+          - alert: HubNodeNotReady
+            expr: kube_node_status_condition{condition="Ready", status="true", cluster="oke-hub"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub node not ready"
+              description: "Node {{ $labels.node }} has been NotReady for 5 minutes."
+
+      - name: HubPodAlerts
+        rules:
+          - alert: HubPodCrashLooping
+            expr: |
+              rate(kube_pod_container_status_restarts_total{cluster="oke-hub", namespace=~"monitoring|argocd"}[15m]) * 60 * 15 > 3
+            for: 10m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "Pod crash-looping on OKE hub"
+              description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) restarted {{ $value | printf \"%.0f\" }} times in 15m."
+
+          - alert: HubContainerOOMKilled
+            expr: |
+              kube_pod_container_status_last_terminated_reason{reason="OOMKilled", cluster="oke-hub", namespace=~"monitoring|argocd"} == 1
+            for: 0m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "Container OOMKilled on OKE hub"
+              description: "{{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container }} was OOMKilled."
+
+          - alert: HubPodStuckPending
+            expr: |
+              kube_pod_status_phase{phase="Pending", cluster="oke-hub", namespace=~"monitoring|argocd"} == 1
+            for: 15m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "Pod stuck Pending on OKE hub"
+              description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been Pending for > 15m."
+
+      - name: HubWorkloadAlerts
+        rules:
+          - alert: HubDeploymentReplicasMismatch
+            expr: |
+              kube_deployment_status_replicas_available{cluster="oke-hub", namespace=~"monitoring|argocd"}
+                != kube_deployment_spec_replicas{cluster="oke-hub", namespace=~"monitoring|argocd"}
+            for: 15m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub Deployment replicas mismatch"
+              description: "Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has {{ $value }} available vs desired."
+
+          - alert: HubStatefulSetReplicasMismatch
+            expr: |
+              kube_statefulset_status_replicas_ready{cluster="oke-hub", namespace=~"monitoring|argocd"}
+                != kube_statefulset_replicas{cluster="oke-hub", namespace=~"monitoring|argocd"}
+            for: 15m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub StatefulSet replicas mismatch"
+              description: "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has {{ $value }} ready vs desired."
+
+          - alert: HubDaemonSetMissScheduled
+            expr: |
+              kube_daemonset_status_desired_number_scheduled{cluster="oke-hub", namespace=~"monitoring|argocd|ingress-nginx|kube-system"}
+                - kube_daemonset_status_current_number_scheduled{cluster="oke-hub", namespace=~"monitoring|argocd|ingress-nginx|kube-system"} > 0
+            for: 10m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "OKE hub DaemonSet not fully scheduled"
+              description: "DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} is missing pods on some nodes."
+
+      - name: HubMonitoringStackHealth
+        rules:
+          - alert: PrometheusServerUnavailable
+            expr: kube_deployment_status_replicas_available{deployment="prometheus-server", namespace="monitoring", cluster="oke-hub"} < 1
+            for: 5m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "Prometheus server unavailable"
+              description: "Deployment monitoring/prometheus-server has 0 available replicas."
+
+          - alert: GrafanaUnavailable
+            expr: kube_deployment_status_replicas_available{deployment="grafana", namespace="monitoring", cluster="oke-hub"} < 1
+            for: 5m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "Grafana unavailable"
+              description: "Deployment monitoring/grafana has 0 available replicas."
+
+          - alert: LokiUnavailable
+            expr: kube_statefulset_status_replicas_ready{statefulset="loki", namespace="monitoring", cluster="oke-hub"} < 1
+            for: 10m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "Loki unavailable"
+              description: "StatefulSet monitoring/loki has 0 ready replicas."
+
+          - alert: TempoUnavailable
+            expr: kube_statefulset_status_replicas_ready{statefulset="tempo", namespace="monitoring", cluster="oke-hub"} < 1
+            for: 10m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "Tempo unavailable"
+              description: "StatefulSet monitoring/tempo has 0 ready replicas."
+
+          - alert: AlertmanagerUnavailable
+            expr: kube_statefulset_status_replicas_ready{statefulset="prometheus-alertmanager", namespace="monitoring", cluster="oke-hub"} < 1
+            for: 10m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "Alertmanager unavailable"
+              description: "StatefulSet monitoring/prometheus-alertmanager has 0 ready replicas."
+
+      - name: HubPrometheusScrapeHealth
+        rules:
+          - alert: HubCadvisorScrapeDown
+            expr: up{job="kubernetes-nodes-cadvisor", cluster="oke-hub"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              cluster: oke-hub
+            annotations:
+              summary: "cAdvisor scrape down"
+              description: "Prometheus cannot scrape cAdvisor for node {{ $labels.service }} (job kubernetes-nodes-cadvisor)."
+
+          - alert: HubKubeletVolumeStatsScrapeDown
+            expr: up{job="kubelet-volume-stats", cluster="oke-hub"} == 0
+            for: 5m
+            labels:
+              severity: warning
+              cluster: oke-hub
+            annotations:
+              summary: "kubelet volume stats scrape down"
+              description: "Prometheus cannot scrape kubelet volume stats for node {{ $labels.instance }} (job kubelet-volume-stats)."
 
       # ──────────────────────────────────────────────
       # Tier 4: AKS Spoke Cluster (aks-canepro)

--- a/hub-docs/GRAFANA-E1-DEFAULT-DASHBOARDS.md
+++ b/hub-docs/GRAFANA-E1-DEFAULT-DASHBOARDS.md
@@ -63,6 +63,7 @@ Beyond your current list, consider adding these for observability-stack and plat
 | **ArgoCD** | **14583** | Argo CD - Application metrics | Prometheus | App sync status, health; if you scrape ArgoCD metrics. |
 | **ArgoCD (alt)** | **14584** | Argo CD - Overview | Prometheus | Overview of Argo CD. |
 | **Alertmanager** | **8010** | Alertmanager | Prometheus | Firing alerts, silences; if you use Alertmanager. |
+| **Alerts overview** | **9578** | Alerts | Prometheus | Useful once Prometheus alert rules exist (uses `ALERTS` / rule metrics). |
 | **Kubernetes API server** | **15762** | Kubernetes / Views / API server | Prometheus | API server latency, errors (dotdc set). |
 | **etcd** | **3070** | etcd | Prometheus | If you scrape etcd metrics. |
 
@@ -160,6 +161,7 @@ If a Loki dashboard panel/variable is accidentally using **Prometheus-style temp
 | 3662 | Prometheus 2.0 Overview | https://grafana.com/grafana/dashboards/3662 |
 | 3663 | Prometheus Stats | https://grafana.com/grafana/dashboards/3663 |
 | 8010 | Alertmanager | https://grafana.com/grafana/dashboards/8010 |
+| 9578 | Alerts | https://grafana.com/grafana/dashboards/9578 |
 | 9614 | NGINX Ingress controller | https://grafana.com/grafana/dashboards/9614 |
 | 12019 | Loki Dashboard | https://grafana.com/grafana/dashboards/12019 |
 | 13186 | Loki Dashboard (alt) | https://grafana.com/grafana/dashboards/13186 |


### PR DESCRIPTION
Adds the Grafana Alerts dashboard (gnet 9578) and extends Prometheus alert rules with hub-focused alerts (node/workload health and core observability component availability).\n\nDocs:\n- Updates docs/ALERTS.md to match the actual rule groups and notes about dashboards showing no data when there are no active alerts.\n\nNotes:\n- Alert rules are defined in helm/prometheus-values.yaml (serverFiles.alerting_rules.yml).\n- Dashboard is provisioned via helm/grafana-values.yaml.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Grafana alerts dashboard for centralized alert monitoring and overview.
  * Introduced comprehensive hub infrastructure monitoring with new alerts for node health, pod stability, workload replicas, and monitoring stack components.

* **Documentation**
  * Updated alerting documentation with expanded guidance, maintenance procedures, and secret restoration steps.
  * Added operational governance documentation for repository management and verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->