### PR TITLE
alerting: fix Alertmanager dashboard N/A by scraping alertmanager metrics

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -270,6 +270,29 @@ Should be `1` for each node.
 
 ---
 
+## Alertmanager Issues
+
+### Grafana Alertmanager dashboard shows `N/A` for all stats
+
+**Symptoms**
+- The Alertmanager dashboard panels show `N/A` for instance count, cluster size, active alerts, silences, etc.
+
+**Root cause**
+Prometheus is not scraping Alertmanager's own `/metrics`. This repo relies on service annotations for `kubernetes-service-endpoints` discovery. If the `prometheus-alertmanager` service is missing `prometheus.io/scrape=true`, the series `alertmanager_*` will not exist, and the dashboard has nothing to render.
+
+**Fix (this repo)**
+`helm/prometheus-values.yaml` adds scrape annotations on the Alertmanager service:
+- `prometheus.io/scrape: "true"`
+- `prometheus.io/port: "9093"`
+- `prometheus.io/path: /metrics`
+
+**Quick verification**
+In Grafana Explore (Prometheus), run:
+```promql
+count(alertmanager_build_info)
+```
+It should be > 0.
+
 ## Ingress & Network Issues
 
 ### NGINX Default Backend Crash (ARM64)

--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -232,6 +232,12 @@ serverFiles:
             regex: prometheus-kube-state-metrics
             target_label: job
             replacement: kube-state-metrics
+          - action: replace
+            source_labels:
+              - __meta_kubernetes_service_name
+            regex: prometheus-alertmanager
+            target_label: job
+            replacement: alertmanager
           # Expose Argo CD metrics with job=<service_name> so gnet dashboards and
           # alert rules can match `job="argocd-*-metrics"`.
           - action: replace
@@ -1105,6 +1111,11 @@ server:
 # Alertmanager configuration
 alertmanager:
   enabled: true
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9093"
+      prometheus.io/path: /metrics
   persistence:
     enabled: false
   resources:


### PR DESCRIPTION
Fixes the Grafana Alertmanager dashboard showing N/A by ensuring Prometheus scrapes alertmanager /metrics.\n\nRoot cause\n- This repo uses annotation-based service discovery (job kubernetes-service-endpoints). The alertmanager Service was not annotated for scraping, so alertmanager_* series were absent.\n\nChanges\n- helm/prometheus-values.yaml: annotate prometheus-alertmanager service for scraping + normalize job label to alertmanager for gnet dashboards.\n- docs/TROUBLESHOOTING.md: add a focused troubleshooting entry with a PromQL verification query.\n\nPost-merge verification\n- In Prometheus/Grafana Explore: count(alertmanager_build_info) > 0\n- Alertmanager dashboard panels populate (instance count, silences, etc.)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Alertmanager dashboard display issues.

* **New Features**
  * Enabled Prometheus monitoring of Alertmanager service with proper scraping configuration and job labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->