### PR TITLE
fix(alerting): Alertmanager SMTP env expansion

### DIFF
--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -1111,6 +1111,10 @@ server:
 # Alertmanager configuration
 alertmanager:
   enabled: true
+  # Alertmanager config uses ${SMTP_*} placeholders. The upstream Alertmanager
+  # binary only expands env vars when `--config.expand-env` is enabled.
+  extraArgs:
+    config.expand-env: "true"
   service:
     annotations:
       prometheus.io/scrape: "true"
@@ -1126,7 +1130,8 @@ alertmanager:
       cpu: 500m
       memory: 512Mi
 
-  extraEnvVars:
+  # NOTE: This chart uses `extraEnv` (not `extraEnvVars`).
+  extraEnv:
     - name: SMTP_PASSWORD
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Fix Alertmanager email notifications by:
- injecting SMTP env vars using the prometheus chart's supported key (alertmanager.extraEnv)
- enabling env expansion in Alertmanager config (--config.expand-env)

Also documents verification steps in docs/TROUBLESHOOTING.md.

Context
- Alertmanager logs showed repeated Gmail 535 BadCredentials even after Secret rotation.
- Root cause was not just "wrong password"; the SMTP env vars were not present in the Alertmanager pod, and the config placeholders ${SMTP_*} were not being expanded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for SMTP configuration issues with Alertmanager, including verification steps for environment variables, configuration expansion settings, and diagnostic procedures using logs and metrics.

* **Configuration**
  * Updated how SMTP environment variables are configured and injected into Alertmanager to enable proper credential expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->