### PR TITLE
fix(alerting): Alertmanager email config rendering (no PVC)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -352,7 +352,13 @@ Apply: `kubectl apply -f k8s/alerting-rules.yaml`
 
 ### Configure Alertmanager Notifications
 
-Edit `k8s/alertmanager-config.yaml` and apply.
+Do not hand-edit Alertmanager configs in-cluster.
+
+This repo manages Alertmanager configuration via Helm values:
+- Alertmanager routing + email receiver: `helm/prometheus-values.yaml` under `alertmanager.config`
+- SMTP credentials (kept out of Git): Kubernetes Secret `monitoring/grafana-smtp-credentials`
+
+If you need to change routing/receivers, change Git and let ArgoCD reconcile.
 
 ---
 

--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -1111,10 +1111,74 @@ server:
 # Alertmanager configuration
 alertmanager:
   enabled: true
-  # Alertmanager config uses ${SMTP_*} placeholders. The upstream Alertmanager
-  # binary only expands env vars when `--config.expand-env` is enabled.
+  # Keep SMTP creds out of Git:
+  # 1) inject SMTP_* from Secret
+  # 2) render a final alertmanager.yml in an initContainer (ConfigMap is read-only)
+  #
+  # IMPORTANT: Alertmanager (v0.31.0) does NOT support `--config.expand-env`.
+  # Instead, we render a concrete config file from the template + env vars.
   extraArgs:
-    config.expand-env: "true"
+    # Override chart default --config.file to point at the rendered file.
+    config.file: /etc/alertmanager-generated/alertmanager.yml
+
+  extraVolumes:
+    - name: alertmanager-generated
+      emptyDir: {}
+
+  extraVolumeMounts:
+    - name: alertmanager-generated
+      mountPath: /etc/alertmanager-generated
+
+  extraInitContainers:
+    - name: render-alertmanager-config
+      image: busybox:1.36.1
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -euf
+          src="/etc/alertmanager/alertmanager.yml"
+          dst="/etc/alertmanager-generated/alertmanager.yml"
+
+          mkdir -p /etc/alertmanager-generated
+          cp "$src" "$dst"
+
+          # Escape for sed replacement (delimiter is '|').
+          esc() { printf '%s' "$1" | sed -e 's/[\\/&|]/\\\\&/g'; }
+
+          sed -i \
+            -e "s|\\${SMTP_FROM}|$(esc "${SMTP_FROM}")|g" \
+            -e "s|\\${SMTP_TO}|$(esc "${SMTP_TO}")|g" \
+            -e "s|\\${SMTP_USER}|$(esc "${SMTP_USER}")|g" \
+            -e "s|\\${SMTP_PASSWORD}|$(esc "${SMTP_PASSWORD}")|g" \
+            "$dst"
+      env:
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana-smtp-credentials
+              key: password
+        - name: SMTP_USER
+          valueFrom:
+            secretKeyRef:
+              name: grafana-smtp-credentials
+              key: user
+        - name: SMTP_FROM
+          valueFrom:
+            secretKeyRef:
+              name: grafana-smtp-credentials
+              key: from_address
+        - name: SMTP_TO
+          valueFrom:
+            secretKeyRef:
+              name: grafana-smtp-credentials
+              key: to_address
+      volumeMounts:
+        - name: config
+          mountPath: /etc/alertmanager
+          readOnly: true
+        - name: alertmanager-generated
+          mountPath: /etc/alertmanager-generated
   service:
     annotations:
       prometheus.io/scrape: "true"


### PR DESCRIPTION
Fix Alertmanager CrashLoopBackOff and enable email notifications without adding any PVC.

What changed
- Alertmanager v0.31.0 does not support `--config.expand-env`.
- Our Alertmanager config uses `${SMTP_*}` placeholders, but secrets must not be committed to Git.

This PR:
- Removes the invalid flag usage by switching Alertmanager to a rendered config file.
- Adds an initContainer that copies the template config from the ConfigMap and replaces `${SMTP_*}` with values from Secret `monitoring/grafana-smtp-credentials`.
- Stores the rendered config in an `emptyDir` (no PVC).
- Updates docs to reflect GitOps-first configuration and adds verification steps.

Expected result
- Alertmanager stops CrashLooping.
- Email notifications work once the Gmail App Password is correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guide to reflect Alertmanager setup via Helm values and Kubernetes Secrets managed in Git with ArgoCD reconciliation, replacing manual cluster edits.
  * Updated troubleshooting guide to address configuration rendering workflow and verification procedures.

* **New Features**
  * Introduced Alertmanager configuration rendering pipeline to support template-based secret injection, enabling GitOps-managed configuration without manual in-cluster modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->