### PR TITLE
fix(alerting): render Alertmanager SMTP placeholders via awk

### DIFF
--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -1141,17 +1141,23 @@ alertmanager:
           dst="/etc/alertmanager-generated/alertmanager.yml"
 
           mkdir -p /etc/alertmanager-generated
-          cp "$src" "$dst"
-
-          # Escape for sed replacement (delimiter is '|').
-          esc() { printf '%s' "$1" | sed -e 's/[\\/&|]/\\\\&/g'; }
-
-          sed -i \
-            -e "s|\\${SMTP_FROM}|$(esc "${SMTP_FROM}")|g" \
-            -e "s|\\${SMTP_TO}|$(esc "${SMTP_TO}")|g" \
-            -e "s|\\${SMTP_USER}|$(esc "${SMTP_USER}")|g" \
-            -e "s|\\${SMTP_PASSWORD}|$(esc "${SMTP_PASSWORD}")|g" \
-            "$dst"
+          # Replace ${SMTP_*} placeholders with env var values. Avoid `sed` here,
+          # as shell interpolation can easily break the literal ${...} match.
+          #
+          # Gmail App Passwords are alphanumeric, and typical email addresses
+          # don't contain '&' or backslashes, so awk replacement is safe.
+          awk \
+            -v from="${SMTP_FROM}" \
+            -v to="${SMTP_TO}" \
+            -v user="${SMTP_USER}" \
+            -v pass="${SMTP_PASSWORD}" \
+            '{
+              gsub(/\\$\\{SMTP_FROM\\}/, from);
+              gsub(/\\$\\{SMTP_TO\\}/, to);
+              gsub(/\\$\\{SMTP_USER\\}/, user);
+              gsub(/\\$\\{SMTP_PASSWORD\\}/, pass);
+              print;
+            }' "$src" > "$dst"
       env:
         - name: SMTP_PASSWORD
           valueFrom:


### PR DESCRIPTION
Alertmanager email config rendering fix.

Problem
- We render `/etc/alertmanager-generated/alertmanager.yml` in an initContainer so secrets stay in Kubernetes (not Git).
- The prior rendering used `sed` expressions that unintentionally expanded `${SMTP_*}` in the *match* pattern, so placeholders were not replaced.
- Result: Alertmanager still attempted SMTP auth using literal `${SMTP_*}` values and Gmail rejected it (535 BadCredentials).

Fix
- Switch rendering to `awk gsub()` to reliably replace `${SMTP_FROM}`, `${SMTP_TO}`, `${SMTP_USER}`, `${SMTP_PASSWORD}` placeholders.

No PVCs
- This continues to use `emptyDir` only (no PVC added).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Alertmanager configuration placeholder substitution mechanism for enhanced reliability in SMTP settings handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->