### PR TITLE
fix(alerting): BusyBox awk regex for SMTP placeholders

### DIFF
--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -1152,10 +1152,12 @@ alertmanager:
             -v user="${SMTP_USER}" \
             -v pass="${SMTP_PASSWORD}" \
             '{
-              gsub(/\\$\\{SMTP_FROM\\}/, from);
-              gsub(/\\$\\{SMTP_TO\\}/, to);
-              gsub(/\\$\\{SMTP_USER\\}/, user);
-              gsub(/\\$\\{SMTP_PASSWORD\\}/, pass);
+              # BusyBox awk treats `\{` as an interval operator; match braces
+              # using character classes for portability.
+              gsub(/\\$[{]SMTP_FROM[}]/, from);
+              gsub(/\\$[{]SMTP_TO[}]/, to);
+              gsub(/\\$[{]SMTP_USER[}]/, user);
+              gsub(/\\$[{]SMTP_PASSWORD[}]/, pass);
               print;
             }' "$src" > "$dst"
       env:


### PR DESCRIPTION
Fix Alertmanager initContainer crash in BusyBox awk.

Symptom
- `prometheus-alertmanager-0` stuck in `Init:CrashLoopBackOff`.
- initContainer logs: `awk: bad regex ... Invalid content of \{\}`.

Root cause
- BusyBox awk interprets `\{` as an interval operator. Our placeholder-matching regex used `\$\{...\}` which triggers this parse error.

Fix
- Use character classes to match braces portably:
  - `\$[{]SMTP_FROM[}]` etc.

No PVCs
- Still uses `emptyDir` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issues with SMTP configuration handling in certain environments. SMTP placeholder substitution now works correctly without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->