### PR TITLE
fix(alerting): render SMTP placeholders reliably

### DIFF
--- a/helm/prometheus-values.yaml
+++ b/helm/prometheus-values.yaml
@@ -1154,10 +1154,13 @@ alertmanager:
             '{
               # BusyBox awk treats `\{` as an interval operator; match braces
               # using character classes for portability.
-              gsub(/\\$[{]SMTP_FROM[}]/, from);
-              gsub(/\\$[{]SMTP_TO[}]/, to);
-              gsub(/\\$[{]SMTP_USER[}]/, user);
-              gsub(/\\$[{]SMTP_PASSWORD[}]/, pass);
+              # Avoid backslashes entirely here: this awk program is single-quoted
+              # in the shell script, so backslashes would be passed through and
+              # could prevent matching the literal `${SMTP_*}` strings.
+              gsub(/[$][{]SMTP_FROM[}]/, from);
+              gsub(/[$][{]SMTP_TO[}]/, to);
+              gsub(/[$][{]SMTP_USER[}]/, user);
+              gsub(/[$][{]SMTP_PASSWORD[}]/, pass);
               print;
             }' "$src" > "$dst"
       env:


### PR DESCRIPTION
Fix Alertmanager config rendering: ensure `${SMTP_*}` placeholders are actually substituted.

Symptom
- `/etc/alertmanager-generated/alertmanager.yml` still contained `${SMTP_*}` after initContainer ran.

Root cause
- The awk program is passed in single quotes; backslashes in the regex are not shell-interpreted and prevented matching the literal `${SMTP_*}` strings.

Fix
- Match the placeholder strings using character classes without backslashes:
  - `[$][{]SMTP_FROM[}]` etc.

Verification
- After ArgoCD sync + pod restart, `grep -n "\\${SMTP_" /etc/alertmanager-generated/alertmanager.yml` returns nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable substitution in Alertmanager's email configuration to properly handle SMTP settings placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->