### PR TITLE
docs: reflect AKS spoke + OOM remediation

### DIFF
--- a/GITOPS-HANDOVER.md
+++ b/GITOPS-HANDOVER.md
@@ -1,6 +1,6 @@
 # Multi-Cluster GitOps Handover
 
-This document serves as the final operational map for the entire Multi-Cluster ecosystem. It consolidates the management of the OKE Hub, the K3s Spoke, and the application stacks into a single source of truth.
+This document serves as the final operational map for the entire Multi-Cluster ecosystem. It consolidates the management of the OKE Hub, the AKS app cluster (`k8.canepro.me`), and the application stacks into a single source of truth.
 
 ## 🗺️ 1. Core Infrastructure Map
 
@@ -17,6 +17,10 @@ This document serves as the final operational map for the entire Multi-Cluster e
 | **Grafana** | https://grafana.canepro.me | Centralized Logs (Loki) & Metrics (Prometheus) |
 | **RocketChat** | https://k8.canepro.me | Rocket.Chat Front-End |
 | **K8s API** | https://k8.canepro.me:6443 | Direct kubectl access to the AKS cluster (may be offline during auto-shutdown windows) |
+
+Notes:
+- `k8.canepro.me` is the current AKS Rocket.Chat cluster and may be offline weekdays 4pm-11pm due to auto-shutdown.
+- The old cluster `k8-canepro-rocketchat` has been retired/deleted.
 
 ### 🔑 ArgoCD Initial Access
 To retrieve the initial `admin` password:
@@ -80,7 +84,7 @@ kubectl -n argocd get secret argocd-initial-admin-secret \
 | Symptom | Primary Cause | First Action |
 |---------|---------------|--------------|
 | **App is "OutOfSync"** | Manual change on cluster or new Git push | Check Diff in ArgoCD UI, then click Sync. |
-| **Pods stuck "Creating"** | Potential Disk Pressure (>85%) | Run `sudo k3s crictl rmi --prune` on the Spoke node. |
+| **Pods stuck "Creating"** | Disk pressure or image pull / registry issues | `kubectl describe pod <pod> -n <ns>` and check Events for `DiskPressure`, `ImagePullBackOff`, or CNI/storage errors. On managed clusters (AKS/OKE), recycle/replace nodes if disk pressure persists. |
 | **"Handshake Error" in logs** | Prometheus Agent protocol mismatch | Verify `scheme: https` in the agent config. |
 | **DNS Resolution Failure** | Missing A-Record or restart delay | Check `nslookup k8.canepro.me` or update `/etc/hosts`. |
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This repository is the GitOps source of truth for a production-ready observabili
 ```mermaid
 flowchart LR
   subgraph Spokes[Spoke Clusters]
-    S1[AKS Spoke] -->|remote_write| P
-    S2[K3s Spoke] -->|remote_write| P
+    S1[AKS Spoke (k8.canepro.me)] -->|remote_write| P
+    S2[Dev Spoke (kind)] -->|remote_write| P
     SN[Other Spokes] -->|remote_write| P
     S1 -->|logs| L
     S2 -->|logs| L

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -416,7 +416,7 @@ Do **not** increase the pod’s memory limit until you have checked node headroo
 
 4. **Decide and apply**
    - **Tight cluster**: Trim limits on under-used workloads in this repo (`helm/grafana-values.yaml`, `helm/prometheus-values.yaml` alertmanager, `helm/nginx-ingress-values.yaml`), then increase the OOM’d workload.
-   - **Enough headroom**: Increase only the OOM’d container (e.g. 512Mi → 768Mi). For **Argo CD application-controller**, change `controller.resources` in `terraform/argocd.tf` (`helm_release.argocd`).
+   - **Enough headroom**: Increase only the OOM’d container (e.g. 512Mi → 768Mi). For **Argo CD application-controller**, change `controller.resources` (requests + limits) in `terraform/argocd.tf` (`helm_release.argocd`), then run `terraform apply`.
 
 **What to check next (per-pod)**
 ```bash

--- a/docs/external-config/ROCKETCHAT-SETUP.md
+++ b/docs/external-config/ROCKETCHAT-SETUP.md
@@ -1,6 +1,6 @@
 # Rocket.Chat Cluster Observability Setup
 
-Use these instructions to configure the `rocketchat-k8s` cluster (or any remote cluster) to send telemetry to the central **Canepro Observability Hub**.
+Use these instructions to configure the `rocketchat-k8s` cluster (AKS, `k8.canepro.me`) or any remote cluster to send telemetry to the central **Canepro Observability Hub**.
 
 ## 1. Credentials
 
@@ -82,4 +82,4 @@ helm upgrade --install promtail grafana/promtail -f values-monitoring.yaml -n mo
 2.  **Check Central Grafana**:
     -   Go to https://grafana.canepro.me
     -   Explore -> Prometheus
-    -   Query: `{cluster="rocketchat-k3s"}` (or whatever `external_labels.cluster` you set)
+    -   Query: `{cluster="aks-canepro"}` (or whatever `external_labels.cluster` you set)

--- a/docs/external-config/prometheus-agent-canepro.yaml
+++ b/docs/external-config/prometheus-agent-canepro.yaml
@@ -23,10 +23,10 @@ data:
     global:
       scrape_interval: 30s
       external_labels:
-        cluster: rocketchat-k3s
+        cluster: aks-canepro
         environment: production
         workspace: production
-        domain: rocketchat.local
+        domain: k8.canepro.me
 
     remote_write:
       - url: https://observability.canepro.me/api/v1/write
@@ -174,4 +174,3 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-agent
   namespace: monitoring
-

--- a/hub-docs/CLUSTER-INFO.md
+++ b/hub-docs/CLUSTER-INFO.md
@@ -188,6 +188,20 @@ Same snapshot date. **Actual** = `kubectl top pods -A --containers`; **Request/L
 
 *— = not set in pod spec.*
 
+### Post-OOM remediation (desired limits in Git)
+
+To reduce OOM risk and free headroom on the Always Free nodes, the following limit trims were made in this repo (2026-02-10):
+
+| Workload | File | Old limit | New limit |
+|---|---|---:|---:|
+| Grafana | `helm/grafana-values.yaml` | 768Mi | 512Mi |
+| Prometheus Alertmanager | `helm/prometheus-values.yaml` | 512Mi | 256Mi |
+| ingress-nginx controller | `helm/nginx-ingress-values.yaml` | 512Mi | 256Mi |
+
+Argo CD is installed by Terraform in this repo. To address `argocd-application-controller` OOMs, bump the controller to **Guaranteed** QoS by setting `controller.resources.requests.memory == controller.resources.limits.memory` (e.g. `768Mi`) in `terraform/argocd.tf`, then run `terraform apply`.
+
+Note: The snapshot tables above reflect whatever was running at capture time. After applying Git changes (Argo CD sync and/or `terraform apply`), re-run the commands below and refresh this snapshot.
+
 **Takeaway:** Memory is the constraining resource. Keep node memory usage under ~85% to avoid pressure and OOM risk; see `docs/TROUBLESHOOTING.md` (HubContainerOOMKilled) and `hub-docs/OPERATIONS-HUB.md` (OOM diagnosis procedure).
 
 ### Commands to refresh this snapshot

--- a/hub-docs/DIAGRAM.md
+++ b/hub-docs/DIAGRAM.md
@@ -6,7 +6,7 @@ This diagram visualizes how data flows from various Spoke clusters and external 
 
 ```mermaid
 graph LR
-    subgraph spokes ["Spoke Clusters (K3s, Podman, etc.)"]
+    subgraph spokes ["Spoke Clusters (AKS, kind, Podman, etc.)"]
         PromAgent[Prometheus Agent]
         LokiAgent[Promtail / FluentBit]
         AppTraces[OTEL SDK / Collector]
@@ -56,4 +56,3 @@ graph LR
 2. **Persistence**: The Hub components store high-velocity data (metrics) on Block Volumes and high-volume data (logs/traces) on OCI Object Storage.
 3. **Visualization**: Grafana queries the backend services internally within the cluster.
 4. **Management**: ArgoCD monitors the repository and applies updates to the Hub cluster itself via Server-Side Apply.
-

--- a/hub-docs/OPERATIONS-HUB.md
+++ b/hub-docs/OPERATIONS-HUB.md
@@ -253,7 +253,7 @@ kubectl get pods -A -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.na
 Identify:
 
 - **OOM’d pod**: needs more headroom (increase limit, or reduce load).
-- **Others with high limit, low actual**: candidates to trim limits to free schedulable memory (e.g. Grafana 768Mi → 512Mi, Alertmanager 512Mi → 256Mi, Argo CD server 512Mi → 256Mi, nginx-ingress 512Mi → 256Mi).
+- **Others with high limit, low actual**: candidates to trim limits to free schedulable memory (e.g. Grafana 768Mi → 512Mi, Alertmanager 512Mi → 256Mi, nginx-ingress 512Mi → 256Mi).
 
 ### 4. Decide remediation
 
@@ -261,7 +261,7 @@ Identify:
 |-----------|--------|
 | Node memory &lt; ~80% and only one pod OOM’d | **Small bump**: increase the OOM’d container limit (e.g. 512Mi → 768Mi). Prefer 768Mi if headroom is tight. |
 | Node memory already high (e.g. ≥80%) | **Trim first**: reduce limits on under-used workloads (in this repo: `helm/grafana-values.yaml`, `helm/prometheus-values.yaml` alertmanager, `helm/nginx-ingress-values.yaml`). Then increase the OOM’d workload (e.g. to 1Gi). |
-| Argo CD application-controller OOM | Controller resources **are** defined in this repo via `terraform/argocd.tf` (`helm_release.argocd`, Helm values `controller.resources`). Increase `controller.resources.limits.memory` (e.g. `768Mi` or `1Gi`). |
+| Argo CD application-controller OOM | Controller resources **are** defined in this repo via `terraform/argocd.tf` (`helm_release.argocd`, Helm values `controller.resources`). Increase **both** `controller.resources.requests.memory` and `controller.resources.limits.memory` together (e.g. `768Mi` or `1Gi`) to keep QoS **Guaranteed**, then run `terraform apply`. |
 
 ### 5. Apply changes (GitOps)
 


### PR DESCRIPTION
Doc-only updates: remove stale K3s spoke references (k8.canepro.me is AKS), align Rocket.Chat agent examples to aks-canepro, and update hub OOM remediation docs to match the actual knobs in this repo (helm limit trims + terraform/argocd.tf controller requests+limits + terraform apply).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated infrastructure references to reflect AKS cluster adoption (k8.canepro.me)
  * Enhanced troubleshooting guidance with diagnostic procedures and remediation steps
  * Expanded operational instructions for resource management and configuration updates
  * Updated monitoring configuration labels to align with current cluster context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->