### PR TITLE
fix: run jenkins bridge before workspace cleanup

### DIFF
--- a/.jenkins/k8s-manifest-validation.Jenkinsfile
+++ b/.jenkins/k8s-manifest-validation.Jenkinsfile
@@ -153,7 +153,7 @@ spec:
   }
   
   post {
-    always {
+    cleanup {
       // Only clean workspace when we ran on an agent; otherwise MissingContextVariableException (no FilePath).
       script { if (env.WORKSPACE?.trim()) { cleanWs() } }
     }

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -216,7 +216,7 @@ EOF
   }
 
   post {
-    always {
+    cleanup {
       // NOTE: Do not archive tfplan output by default; plan output can contain sensitive resource attributes.
       // Only clean workspace when we ran on an agent; otherwise MissingContextVariableException (no FilePath).
       script { if (env.WORKSPACE?.trim()) { cleanWs() } }


### PR DESCRIPTION
Fixes GrafanaLocal Jenkins failure notification ordering so the PipelineHealer bridge runs before  removes the workspace.\n\nRoot cause from live Jenkins logs:  ran before , so  was missing when the bridge notification tried to run.\n\nThis switches the affected pipelines to , which preserves the workspace for failure handlers and still cleans it afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jenkins pipeline post-build cleanup configurations in validation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->