### PR TITLE
fix: capture direct Jenkins bridge excerpts

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -161,3 +161,12 @@ Failed Jenkins runs can also be pushed into PipelineHealer through the signed Je
   - `oci-vault` `ClusterSecretStore`
 
 If those credentials are missing, the Jenkinsfiles skip bridge notification and continue with the existing GitHub issue/comment behavior.
+
+### Recommended bridge capture pattern
+
+Use the repo-shipped shell helper `.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh` to wrap failure-prone `sh` steps. It captures the real command output into `${WORKSPACE}/.pipelinehealer-log-excerpt.txt` without relying on Jenkins-specific Pipeline plugins or `currentBuild.rawBuild` access.
+
+For bridge-enabled pipelines:
+- keep workspace cleanup in `post { cleanup { ... } }`, not `post { always { ... } }`, so failure handlers still have access to the checked-out bridge scripts and captured excerpt
+- export `PH_LOG_EXCERPT_FILE` from the failure block when the excerpt file exists
+- keep the existing bridge sender (`send-pipelinehealer-bridge.sh`) as the single signed POST implementation

--- a/.jenkins/k8s-manifest-validation.Jenkinsfile
+++ b/.jenkins/k8s-manifest-validation.Jenkinsfile
@@ -47,6 +47,7 @@ spec:
     stage('Install Tools') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           apk add --no-cache curl openssl tar gzip
           # Helm (needs openssl for checksum verification)
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sh || true
@@ -66,6 +67,7 @@ spec:
           fi
           helm version || true
           kubeconform -v || true
+SCRIPT
         '''
       }
     }
@@ -75,6 +77,7 @@ spec:
     stage('ArgoCD App Validation') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate each ArgoCD Application manifest
           # These are the GitOps control plane definitions
           for app in argocd/applications/*.yaml; do
@@ -83,6 +86,7 @@ spec:
               kubeconform -strict -ignore-missing-schemas "$app" || exit 1
             fi
           done
+SCRIPT
         '''
       }
     }
@@ -94,6 +98,7 @@ spec:
       steps {
         dir('helm') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Find all Helm chart directories with values.yaml
             for chart_dir in */; do
               if [ -f "${chart_dir}values.yaml" ]; then
@@ -104,6 +109,7 @@ spec:
                 kubeconform -strict /tmp/"$chart_name"-manifests.yaml || exit 1
               fi
             done
+SCRIPT
           '''
         }
       }
@@ -115,6 +121,7 @@ spec:
     stage('K8s Manifest Validation') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate raw Kubernetes manifests (non-Helm)
           # These are typically Ingress, ConfigMaps, Secrets, etc.
           if [ -d "k8s" ]; then
@@ -125,6 +132,7 @@ spec:
               fi
             done
           fi
+SCRIPT
         '''
       }
     }
@@ -135,6 +143,7 @@ spec:
     stage('YAML Lint') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install yamllint if not available
           apk add --no-cache yamllint || true
           
@@ -147,13 +156,14 @@ spec:
           # Lint raw Kubernetes manifests
           yamllint -c .yamllint.yaml k8s/
           # || true: warnings don't fail build, only errors
+SCRIPT
         '''
       }
     }
   }
   
   post {
-    always {
+    cleanup {
       // Only clean workspace when we ran on an agent; otherwise MissingContextVariableException (no FilePath).
       script { if (env.WORKSPACE?.trim()) { cleanWs() } }
     }
@@ -186,6 +196,9 @@ spec:
                 export PH_FAILURE_STAGE="k8s-manifest-validation"
                 export PH_FAILURE_SUMMARY="Jenkins Kubernetes manifest validation failed"
                 export PH_RESULT="FAILURE"
+                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                fi
                 bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''

--- a/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
+++ b/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+OUTPUT_FILE="${1:?usage: capture-pipelinehealer-bridge-excerpt.sh <output-file>}"
+CAPTURE_SHELL="${PH_CAPTURE_SHELL:-/bin/sh}"
+STATUS_FILE="$(mktemp)"
+SCRIPT_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE" "$SCRIPT_FILE"' EXIT
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+cat > "$SCRIPT_FILE"
+chmod +x "$SCRIPT_FILE"
+
+if [ ! -x "$CAPTURE_SHELL" ] && ! command -v "$CAPTURE_SHELL" >/dev/null 2>&1; then
+  echo "PipelineHealer bridge capture: shell not found: $CAPTURE_SHELL" >&2
+  exit 1
+fi
+
+(
+  set +e
+  "$CAPTURE_SHELL" "$SCRIPT_FILE" 2>&1
+  echo $? > "$STATUS_FILE"
+) | tee "$OUTPUT_FILE"
+
+STATUS="$(cat "$STATUS_FILE" 2>/dev/null || echo 1)"
+exit "$STATUS"

--- a/.jenkins/security-validation.Jenkinsfile
+++ b/.jenkins/security-validation.Jenkinsfile
@@ -68,6 +68,7 @@ spec:
       }
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install required tools
           # Alpine-based agent: install dependencies via apk
           apk add --no-cache \
@@ -123,6 +124,7 @@ spec:
           checkov --version || echo "checkov not installed"
           trivy --version || echo "trivy not installed"
           kube-score version || echo "kube-score not installed"
+SCRIPT
         '''
       }
     }
@@ -135,11 +137,13 @@ spec:
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Run tfsec scan and output JSON results
             tfsec . --format json --out ${WORKSPACE}/${TFSEC_OUTPUT} || true
             
             # Also output human-readable format for logs
             tfsec . --format default || true
+SCRIPT
           '''
         }
       }
@@ -153,6 +157,7 @@ spec:
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Remove any existing file or directory so readJSON later sees a file (checkov can create a dir)
             rm -rf "${WORKSPACE}/${CHECKOV_OUTPUT}"
             # Run checkov scan on Terraform files
@@ -168,6 +173,7 @@ spec:
             fi
             # Also output CLI format for logs
             checkov -d . --framework terraform || true
+SCRIPT
           '''
         }
       }
@@ -180,6 +186,7 @@ spec:
       }
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Scan Kubernetes manifests in ops/manifests/
           if [ -d "ops/manifests" ] && command -v kube-score >/dev/null 2>&1; then
             kube-score score ops/manifests/*.yaml --output-format json > kube-score-results.json || true
@@ -192,6 +199,7 @@ spec:
           if [ -f "/tmp/manifests.yaml" ]; then
             kube-score score /tmp/manifests.yaml --output-format json > helm-kube-score-results.json || true
           fi
+SCRIPT
         '''
       }
     }
@@ -236,9 +244,11 @@ spec:
               if (line.contains(':')) {
                 def image = line.trim()
                 sh """
+                  cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                   echo "Scanning image: ${image}"
                   trivy image --format json --output ${WORKSPACE}/trivy-${image.replaceAll('[/: ]', '-')}.json ${image} || true
                   trivy image ${image} || true
+SCRIPT
                 """
               }
             }
@@ -257,6 +267,7 @@ spec:
       steps {
         script {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             python3 - <<'PY'
 import json, os, datetime
 
@@ -346,6 +357,7 @@ with open("risk-counts.env", "w") as f:
 
 print("Risk Assessment:", report)
 PY
+SCRIPT
           '''
 
           // Never fail the build due to findings
@@ -530,6 +542,9 @@ Remediation: create PR(s) manually to fix. This issue is updated on each run."
         }
       }
     }
+    cleanup {
+      script { if (env.WORKSPACE?.trim()) { cleanWs() } }
+    }
     success {
       echo '✅ Security validation completed'
     }
@@ -628,6 +643,9 @@ EOF
                 export PH_FAILURE_STAGE="security-validation"
                 export PH_FAILURE_SUMMARY="Scheduled Jenkins security validation failed"
                 export PH_RESULT="FAILURE"
+                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                fi
                 bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -132,9 +132,12 @@ EOF
     // Stage 3: Format Check
     stage('Terraform Format') {
       steps {
-        dir('terraform') {
-          sh 'terraform fmt -check -recursive'
-        }
+        sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cd terraform
+          terraform fmt -check -recursive
+SCRIPT
+        '''
       }
     }
 
@@ -148,25 +151,27 @@ EOF
               string(credentialsId: 'oci-s3-access-key', variable: 'S3_ACCESS_KEY'),
               string(credentialsId: 'oci-s3-secret-key', variable: 'S3_SECRET_KEY')
             ]) {
-              dir('terraform') {
-                sh '''
-                  terraform init \
-                    -backend-config="access_key=${S3_ACCESS_KEY}" \
-                    -backend-config="secret_key=${S3_SECRET_KEY}"
-                  echo "--- Backend state list (verify Jenkins sees same state as local) ---"
-                  terraform state list || true
-                  terraform validate
-                '''
-              }
-            }
-          } else {
-            dir('terraform') {
               sh '''
-                echo "OCI parameters not set; running init -backend=false and validate (no plan)."
-                terraform init -backend=false
+                cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                cd terraform
+                terraform init \
+                  -backend-config="access_key=${S3_ACCESS_KEY}" \
+                  -backend-config="secret_key=${S3_SECRET_KEY}"
+                echo "--- Backend state list (verify Jenkins sees same state as local) ---"
+                terraform state list || true
                 terraform validate
+SCRIPT
               '''
             }
+          } else {
+            sh '''
+              cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              cd terraform
+              echo "OCI parameters not set; running init -backend=false and validate (no plan)."
+              terraform init -backend=false
+              terraform validate
+SCRIPT
+            '''
           }
         }
       }
@@ -182,41 +187,35 @@ EOF
           string(credentialsId: 'oci-s3-secret-key', variable: 'S3_SECRET_KEY'),
           string(credentialsId: 'oci-ssh-public-key', variable: 'SSH_PUBLIC_KEY')
         ]) {
-          dir('terraform') {
-            sh '''
-              # Export Terraform vars (SSH key doesn't have S3 signature issues)
-              export TF_VAR_ssh_public_key="$SSH_PUBLIC_KEY"
-              
-              # Ensure OCI key is in place
-              cp "$OCI_KEY_FILE" ~/.oci/oci_api_key.pem
-              chmod 600 ~/.oci/oci_api_key.pem
-              
-              # Run terraform plan
-              # Note: Backend already initialized in previous stage with credentials
-              terraform plan \
-                -no-color \
-                -input=false \
-                -out=tfplan \
-                -detailed-exitcode || PLAN_EXIT=$?
-              
-              # Exit codes: 0 = no changes, 1 = error, 2 = changes present
-              if [ "${PLAN_EXIT:-0}" = "1" ]; then
-                echo "Terraform plan failed"
-                exit 1
-              elif [ "${PLAN_EXIT:-0}" = "2" ]; then
-                echo "Changes detected in plan"
-              else
-                echo "No changes detected"
-              fi
-            '''
-          }
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cd terraform
+            export TF_VAR_ssh_public_key="$SSH_PUBLIC_KEY"
+            cp "$OCI_KEY_FILE" ~/.oci/oci_api_key.pem
+            chmod 600 ~/.oci/oci_api_key.pem
+            terraform plan \
+              -no-color \
+              -input=false \
+              -out=tfplan \
+              -detailed-exitcode || PLAN_EXIT=$?
+
+            if [ "${PLAN_EXIT:-0}" = "1" ]; then
+              echo "Terraform plan failed"
+              exit 1
+            elif [ "${PLAN_EXIT:-0}" = "2" ]; then
+              echo "Changes detected in plan"
+            else
+              echo "No changes detected"
+            fi
+SCRIPT
+          '''
         }
       }
     }
   }
 
   post {
-    always {
+    cleanup {
       // NOTE: Do not archive tfplan output by default; plan output can contain sensitive resource attributes.
       // Only clean workspace when we ran on an agent; otherwise MissingContextVariableException (no FilePath).
       script { if (env.WORKSPACE?.trim()) { cleanWs() } }
@@ -250,6 +249,9 @@ EOF
                 export PH_FAILURE_STAGE="terraform-validation"
                 export PH_FAILURE_SUMMARY="Jenkins Terraform validation failed"
                 export PH_RESULT="FAILURE"
+                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                fi
                 bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''

--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -56,6 +56,7 @@ spec:
       }
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Alpine-based agent: install tools via apk (openssl required for Helm install script checksum)
           apk add --no-cache curl jq git bash yq openssl github-cli || \
             apk add --no-cache curl jq git bash yq openssl
@@ -97,6 +98,7 @@ ensure_label() {
     -d "$LABEL_JSON" >/dev/null 2>&1 || true
 }
 ENSURE_LABEL_EOF
+SCRIPT
         '''
       }
     }
@@ -109,6 +111,7 @@ ENSURE_LABEL_EOF
       steps {
         script {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Add Helm repositories
             helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true
             helm repo add grafana https://grafana.github.io/helm-charts 2>/dev/null || true
@@ -151,10 +154,12 @@ ENSURE_LABEL_EOF
             echo "METRICS_SERVER_LATEST=$(helm search repo metrics-server/metrics-server --versions 2>/dev/null | grep -v NAME | head -1 | awk '{print $2}' || echo '')" >> versions.env
             
             cat versions.env
+SCRIPT
           '''
           
           // Build update list and reports in shell (avoid Groovy JSON sandbox restrictions)
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             set -e
             components="GRAFANA LOKI PROMTAIL TEMPO PROMETHEUS NGINX METRICS_SERVER"
             updates='[]'
@@ -223,6 +228,7 @@ EOF
               --argjson updates "$(cat chart-updates.json)" \
               '{timestamp:$ts, high:$high, medium:$medium, total:$total, updates:$updates}' \
               > "${UPDATE_REPORT}"
+SCRIPT
           '''
         }
       }
@@ -677,6 +683,9 @@ EOF
                 export PH_FAILURE_STAGE="version-check"
                 export PH_FAILURE_SUMMARY="Scheduled Jenkins version check failed"
                 export PH_RESULT="FAILURE"
+                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                fi
                 bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''


### PR DESCRIPTION
## Summary
- add a plugin-free shell helper to capture direct Jenkins failure excerpts for PipelineHealer
- wrap the bridge-enabled validation stages so failure handling sends captured output instead of relying on console scraping
- keep cleanup in post cleanup blocks and document the supported bridge capture pattern

## Testing
- bash -n .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
- git diff --check
