### PR TITLE
fix: use absolute paths for bridge capture scripts and add consoleText API fallback

### DIFF
--- a/.jenkins/k8s-manifest-validation.Jenkinsfile
+++ b/.jenkins/k8s-manifest-validation.Jenkinsfile
@@ -187,7 +187,7 @@ SCRIPT
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
               if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
                 def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
-                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+                bridgeEvidence.writeLogExcerpt()
               }
               sh '''
                 set +e

--- a/.jenkins/k8s-manifest-validation.Jenkinsfile
+++ b/.jenkins/k8s-manifest-validation.Jenkinsfile
@@ -47,7 +47,7 @@ spec:
     stage('Install Tools') {
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           apk add --no-cache curl openssl tar gzip
           # Helm (needs openssl for checksum verification)
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sh || true
@@ -77,7 +77,7 @@ SCRIPT
     stage('ArgoCD App Validation') {
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate each ArgoCD Application manifest
           # These are the GitOps control plane definitions
           for app in argocd/applications/*.yaml; do
@@ -98,7 +98,7 @@ SCRIPT
       steps {
         dir('helm') {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Find all Helm chart directories with values.yaml
             for chart_dir in */; do
               if [ -f "${chart_dir}values.yaml" ]; then
@@ -121,7 +121,7 @@ SCRIPT
     stage('K8s Manifest Validation') {
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate raw Kubernetes manifests (non-Helm)
           # These are typically Ingress, ConfigMaps, Secrets, etc.
           if [ -d "k8s" ]; then
@@ -143,7 +143,7 @@ SCRIPT
     stage('YAML Lint') {
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install yamllint if not available
           apk add --no-cache yamllint || true
           
@@ -185,6 +185,10 @@ SCRIPT
             string(credentialsId: "${env.PIPELINEHEALER_BRIDGE_SECRET_CREDENTIALS}", variable: 'PH_BRIDGE_SECRET'),
           ]) {
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
+              if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
+                def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
+                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+              }
               sh '''
                 set +e
                 export PH_REPOSITORY="${GITHUB_REPO}"
@@ -203,7 +207,7 @@ SCRIPT
                 if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
                   export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 fi
-                bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+                bash "${WORKSPACE}/.jenkins/scripts/send-pipelinehealer-bridge.sh" >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''
             } else {

--- a/.jenkins/scripts/pipelinehealer-bridge-evidence.groovy
+++ b/.jenkins/scripts/pipelinehealer-bridge-evidence.groovy
@@ -1,0 +1,53 @@
+def fetchConsoleText(String outputPath, int maxLines, int maxChars, String authArg = '') {
+  return sh(returnStatus: true, script: """
+    set +e
+    EXCERPT_TMP='${outputPath}.tmp'
+    HTTP_CODE=\$(curl -sS ${authArg} -o "\$EXCERPT_TMP" -w '%{http_code}' "\${BUILD_URL}consoleText" 2>/dev/null)
+    if [ "\$HTTP_CODE" = "200" ] && [ -s "\$EXCERPT_TMP" ]; then
+      tail -n ${maxLines} "\$EXCERPT_TMP" | sed 's/\\x1b\\[[0-9;]*m//g; s/\\*\\{4,\\}/****/g' | tail -c ${maxChars} > '${outputPath}'
+      rm -f "\$EXCERPT_TMP"
+      echo "PipelineHealer bridge evidence: captured \$(wc -c < '${outputPath}') bytes via consoleText API"
+      exit 0
+    fi
+    rm -f "\$EXCERPT_TMP"
+    echo "PipelineHealer bridge evidence: consoleText API returned HTTP \$HTTP_CODE"
+    exit 1
+  """) == 0
+}
+
+def writeLogExcerpt(String outputPath = '.pipelinehealer-log-excerpt.txt', int maxLines = 120, int maxChars = 20000) {
+  echo "PipelineHealer bridge evidence: writeLogExcerpt called (outputPath=${outputPath})"
+
+  if (fileExists(outputPath)) {
+    def existing = readFile(outputPath).trim()
+    if (existing) {
+      echo "PipelineHealer bridge evidence: reusing existing excerpt (${existing.length()} chars)"
+      return true
+    }
+  }
+
+  echo 'PipelineHealer bridge evidence: fetching console text via BUILD_URL API...'
+
+  def captured = false
+  try {
+    withCredentials([usernamePassword(
+      credentialsId: 'jenkins-api-token',
+      usernameVariable: 'JENKINS_API_USER',
+      passwordVariable: 'JENKINS_API_TOKEN',
+    )]) {
+      captured = fetchConsoleText(outputPath, maxLines, maxChars, '-u "$JENKINS_API_USER:$JENKINS_API_TOKEN"')
+    }
+  } catch (err) {
+    echo "PipelineHealer bridge evidence: jenkins-api-token credential not configured (${err}); trying unauthenticated..."
+    captured = fetchConsoleText(outputPath, maxLines, maxChars)
+  }
+
+  if (captured) {
+    return true
+  }
+
+  echo 'PipelineHealer bridge evidence: all excerpt capture methods failed.'
+  return false
+}
+
+return this

--- a/.jenkins/scripts/pipelinehealer-bridge-evidence.groovy
+++ b/.jenkins/scripts/pipelinehealer-bridge-evidence.groovy
@@ -19,9 +19,9 @@ def writeLogExcerpt(String outputPath = '.pipelinehealer-log-excerpt.txt', int m
   echo "PipelineHealer bridge evidence: writeLogExcerpt called (outputPath=${outputPath})"
 
   if (fileExists(outputPath)) {
-    def existing = readFile(outputPath).trim()
-    if (existing) {
-      echo "PipelineHealer bridge evidence: reusing existing excerpt (${existing.length()} chars)"
+    if (sh(returnStatus: true, script: "test -s '${outputPath}'") == 0) {
+      def existingBytes = sh(returnStdout: true, script: "wc -c < '${outputPath}'").trim()
+      echo "PipelineHealer bridge evidence: reusing existing excerpt (${existingBytes} bytes)"
       return true
     }
   }
@@ -29,16 +29,24 @@ def writeLogExcerpt(String outputPath = '.pipelinehealer-log-excerpt.txt', int m
   echo 'PipelineHealer bridge evidence: fetching console text via BUILD_URL API...'
 
   def captured = false
+  def authAttempted = false
   try {
     withCredentials([usernamePassword(
       credentialsId: 'jenkins-api-token',
       usernameVariable: 'JENKINS_API_USER',
       passwordVariable: 'JENKINS_API_TOKEN',
     )]) {
+      authAttempted = true
       captured = fetchConsoleText(outputPath, maxLines, maxChars, '-u "$JENKINS_API_USER:$JENKINS_API_TOKEN"')
     }
   } catch (err) {
-    echo "PipelineHealer bridge evidence: jenkins-api-token credential not configured (${err}); trying unauthenticated..."
+    echo "PipelineHealer bridge evidence: jenkins-api-token credential not configured (${err}); will try unauthenticated..."
+  }
+
+  if (!captured) {
+    if (authAttempted) {
+      echo 'PipelineHealer bridge evidence: authenticated consoleText fetch failed; trying unauthenticated...'
+    }
     captured = fetchConsoleText(outputPath, maxLines, maxChars)
   }
 

--- a/.jenkins/security-validation.Jenkinsfile
+++ b/.jenkins/security-validation.Jenkinsfile
@@ -634,7 +634,7 @@ EOF
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
               if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
                 def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
-                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+                bridgeEvidence.writeLogExcerpt()
               }
               sh '''
                 set +e

--- a/.jenkins/security-validation.Jenkinsfile
+++ b/.jenkins/security-validation.Jenkinsfile
@@ -68,7 +68,7 @@ spec:
       }
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install required tools
           # Alpine-based agent: install dependencies via apk
           apk add --no-cache \
@@ -137,7 +137,7 @@ SCRIPT
       steps {
         dir('terraform') {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Run tfsec scan and output JSON results
             tfsec . --format json --out ${WORKSPACE}/${TFSEC_OUTPUT} || true
             
@@ -157,7 +157,7 @@ SCRIPT
       steps {
         dir('terraform') {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Remove any existing file or directory so readJSON later sees a file (checkov can create a dir)
             rm -rf "${WORKSPACE}/${CHECKOV_OUTPUT}"
             # Run checkov scan on Terraform files
@@ -186,7 +186,7 @@ SCRIPT
       }
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Scan Kubernetes manifests in ops/manifests/
           if [ -d "ops/manifests" ] && command -v kube-score >/dev/null 2>&1; then
             kube-score score ops/manifests/*.yaml --output-format json > kube-score-results.json || true
@@ -244,7 +244,7 @@ SCRIPT
               if (line.contains(':')) {
                 def image = line.trim()
                 sh """
-                  cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "\${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                  cat <<'SCRIPT' | sh "\${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "\${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                   echo "Scanning image: ${image}"
                   trivy image --format json --output \${WORKSPACE}/trivy-${image.replaceAll('[/: ]', '-')}.json ${image} || true
                   trivy image ${image} || true
@@ -267,7 +267,7 @@ SCRIPT
       steps {
         script {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             python3 - <<'PY'
 import json, os, datetime
 
@@ -632,6 +632,10 @@ EOF
             string(credentialsId: "${env.PIPELINEHEALER_BRIDGE_SECRET_CREDENTIALS}", variable: 'PH_BRIDGE_SECRET'),
           ]) {
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
+              if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
+                def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
+                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+              }
               sh '''
                 set +e
                 export PH_REPOSITORY="${GITHUB_REPO}"
@@ -643,9 +647,6 @@ EOF
                   PH_BRANCH_VALUE="${BRANCH_NAME:-unknown}"
                 fi
                 export PH_BRANCH="${PH_BRANCH_VALUE}"
-                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
-                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
-                fi
                 export PH_COMMIT_SHA="${GIT_COMMIT:-}"
                 export PH_FAILURE_STAGE="security-validation"
                 export PH_FAILURE_SUMMARY="Scheduled Jenkins security validation failed"
@@ -653,7 +654,7 @@ EOF
                 if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
                   export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 fi
-                bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+                bash "${WORKSPACE}/.jenkins/scripts/send-pipelinehealer-bridge.sh" >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''
             } else {

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -240,7 +240,7 @@ SCRIPT
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
               if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
                 def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
-                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+                bridgeEvidence.writeLogExcerpt()
               }
               sh '''
                 set +e

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -133,7 +133,7 @@ EOF
     stage('Terraform Format') {
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           cd terraform
           terraform fmt -check -recursive
 SCRIPT
@@ -152,7 +152,7 @@ SCRIPT
               string(credentialsId: 'oci-s3-secret-key', variable: 'S3_SECRET_KEY')
             ]) {
               sh '''
-                cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 cd terraform
                 terraform init \
                   -backend-config="access_key=${S3_ACCESS_KEY}" \
@@ -165,7 +165,7 @@ SCRIPT
             }
           } else {
             sh '''
-              cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
               cd terraform
               echo "OCI parameters not set; running init -backend=false and validate (no plan)."
               terraform init -backend=false
@@ -188,7 +188,7 @@ SCRIPT
           string(credentialsId: 'oci-ssh-public-key', variable: 'SSH_PUBLIC_KEY')
         ]) {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             cd terraform
             export TF_VAR_ssh_public_key="$SSH_PUBLIC_KEY"
             cp "$OCI_KEY_FILE" ~/.oci/oci_api_key.pem
@@ -238,6 +238,10 @@ SCRIPT
             string(credentialsId: "${env.PIPELINEHEALER_BRIDGE_SECRET_CREDENTIALS}", variable: 'PH_BRIDGE_SECRET'),
           ]) {
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
+              if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
+                def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
+                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+              }
               sh '''
                 set +e
                 export PH_REPOSITORY="${GITHUB_REPO}"
@@ -249,9 +253,6 @@ SCRIPT
                   PH_BRANCH_VALUE="${BRANCH_NAME:-unknown}"
                 fi
                 export PH_BRANCH="${PH_BRANCH_VALUE}"
-                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
-                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
-                fi
                 export PH_COMMIT_SHA="${GIT_COMMIT:-}"
                 export PH_FAILURE_STAGE="terraform-validation"
                 export PH_FAILURE_SUMMARY="Jenkins Terraform validation failed"
@@ -259,7 +260,7 @@ SCRIPT
                 if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
                   export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 fi
-                bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+                bash "${WORKSPACE}/.jenkins/scripts/send-pipelinehealer-bridge.sh" >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''
             } else {

--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -56,7 +56,7 @@ spec:
       }
       steps {
         sh '''
-          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Alpine-based agent: install tools via apk (openssl required for Helm install script checksum)
           apk add --no-cache curl jq git bash yq openssl github-cli || \
             apk add --no-cache curl jq git bash yq openssl
@@ -111,7 +111,7 @@ SCRIPT
       steps {
         script {
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Add Helm repositories
             helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true
             helm repo add grafana https://grafana.github.io/helm-charts 2>/dev/null || true
@@ -159,7 +159,7 @@ SCRIPT
           
           // Build update list and reports in shell (avoid Groovy JSON sandbox restrictions)
           sh '''
-            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            cat <<'SCRIPT' | sh "${WORKSPACE}/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh" "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             set -e
             components="GRAFANA LOKI PROMTAIL TEMPO PROMETHEUS NGINX METRICS_SERVER"
             updates='[]'
@@ -672,6 +672,10 @@ EOF
             string(credentialsId: "${env.PIPELINEHEALER_BRIDGE_SECRET_CREDENTIALS}", variable: 'PH_BRIDGE_SECRET'),
           ]) {
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
+              if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
+                def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
+                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+              }
               sh '''
                 set +e
                 export PH_REPOSITORY="${GITHUB_REPO}"
@@ -683,9 +687,6 @@ EOF
                   PH_BRANCH_VALUE="${BRANCH_NAME:-unknown}"
                 fi
                 export PH_BRANCH="${PH_BRANCH_VALUE}"
-                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
-                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
-                fi
                 export PH_COMMIT_SHA="${GIT_COMMIT:-}"
                 export PH_FAILURE_STAGE="version-check"
                 export PH_FAILURE_SUMMARY="Scheduled Jenkins version check failed"
@@ -693,7 +694,7 @@ EOF
                 if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
                   export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 fi
-                bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
+                bash "${WORKSPACE}/.jenkins/scripts/send-pipelinehealer-bridge.sh" >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''
             } else {

--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -674,7 +674,7 @@ EOF
             if (fileExists('.jenkins/scripts/send-pipelinehealer-bridge.sh')) {
               if (fileExists('.jenkins/scripts/pipelinehealer-bridge-evidence.groovy')) {
                 def bridgeEvidence = load '.jenkins/scripts/pipelinehealer-bridge-evidence.groovy'
-                bridgeEvidence.writeLogExcerpt("${env.WORKSPACE}/.pipelinehealer-log-excerpt.txt")
+                bridgeEvidence.writeLogExcerpt()
               }
               sh '''
                 set +e


### PR DESCRIPTION
## Summary

- **Fix relative path bug**: All `capture-pipelinehealer-bridge-excerpt.sh` and `send-pipelinehealer-bridge.sh` invocations now use `${WORKSPACE}/...` absolute paths, preventing "No such file" errors when called inside `dir()` blocks
- **Add Groovy consoleText API fallback**: New `pipelinehealer-bridge-evidence.groovy` fetches console text via Jenkins API (authenticated with `jenkins-api-token` credential, graceful unauthenticated fallback) with ANSI/credential-mask sanitization
- **Integrate fallback in all Jenkinsfiles**: All 4 pipeline `post { failure }` blocks now invoke the Groovy evidence helper before the bridge sender, ensuring PipelineHealer always gets log evidence

This is the same root cause and fix pattern applied in [rocketchat-k8s PR #90](https://github.com/Canepro/rocketchat-k8s/pull/90).

Closes #64
Closes #65

## Test plan

- [ ] Verify Jenkins PR check passes (branch build already succeeded)
- [ ] Trigger a failure build and confirm PipelineHealer receives `log_excerpt` evidence instead of `summary_only`
- [ ] Confirm capture script paths resolve correctly when stages use `dir()` blocks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline robustness through enhanced script path resolution mechanisms across all validation stages.
  * Strengthened failure notification and comprehensive log collection capabilities to facilitate better error diagnosis and troubleshooting.
  * Refined pipeline infrastructure to ensure consistent and reliable script invocation throughout the validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->