### PR TITLE
Prepare Argo CD auth hardening

### DIFF
--- a/GITOPS-HANDOVER.md
+++ b/GITOPS-HANDOVER.md
@@ -22,12 +22,16 @@ Notes:
 - `k8.canepro.me` is the current AKS Rocket.Chat cluster and may be offline weekdays 4pm-11pm due to auto-shutdown.
 - The old cluster `k8-canepro-rocketchat` has been retired/deleted.
 
-### 🔑 ArgoCD Initial Access
-To retrieve the initial `admin` password:
-```bash
-kubectl -n argocd get secret argocd-initial-admin-secret \
-  -o jsonpath="{.data.password}" | base64 -d ; echo
-```
+### 🔑 ArgoCD Access Posture
+The local `admin` account is bootstrap/break-glass only. Do not paste the
+initial admin password into chat, reports, tickets, logs, or shell transcripts.
+Retrieve it only in a private operator shell when emergency recovery requires
+it, then rotate or disable the account after SSO is proven.
+
+SSO cutover must happen in this order: provision OIDC app and client secret,
+add the approved admin group to `k8s/argocd-rbac-config.yaml`, enable OIDC in
+Terraform, prove login/admin access, then disable local admin in a separate
+approved change.
 
 ## 📂 3. GitOps Configuration (Sources of Truth)
 

--- a/hub-docs/ARGOCD-RUNBOOK.md
+++ b/hub-docs/ARGOCD-RUNBOOK.md
@@ -9,13 +9,33 @@ All applications are managed by Argo CD with `prune: true` and `selfHeal: true`.
 
 ## Initial Setup & Access
 
-### Retrieve Admin Password
-If you need the initial admin password for the ArgoCD UI:
+### Local Admin And SSO Posture
 
-```bash
-kubectl -n argocd get secret argocd-initial-admin-secret \
-  -o jsonpath="{.data.password}" | base64 -d ; echo
-```
+The built-in `admin` account is a bootstrap and break-glass control. Keep it
+enabled until SSO login, admin group mapping, and recovery access are proven.
+
+Do not paste the initial admin password into chat, reports, tickets, logs, or
+shell transcripts. If emergency recovery requires it, retrieve it only in a
+private operator shell, then rotate or disable the account after SSO is proven.
+
+### SSO Cutover Sequence
+
+1. Provision an OIDC application for `https://argocd.canepro.me/auth/callback`
+   with MFA-backed users/groups.
+2. Create `Secret argocd/argocd-oidc-client-secret` with key `clientSecret`
+   through the approved secret-management path. Do not commit or print the
+   value.
+3. Add the exact approved admin group mapping to
+   `k8s/argocd-rbac-config.yaml`:
+   `g, <approved-oidc-admin-group>, role:admin`.
+4. Set Terraform variables:
+   - `argocd_oidc_enabled=true`
+   - `argocd_oidc_name=<provider display name>`
+   - `argocd_oidc_issuer_url=<issuer URL>`
+   - `argocd_oidc_client_id=<client ID>`
+5. Apply and verify SSO login, group claims, admin mapping, and app visibility.
+6. Only after SSO and recovery access are proven, set
+   `argocd_local_admin_enabled=false` in a separate approved change.
 
 ## How to think about updates
 
@@ -251,5 +271,4 @@ export KUBECONFIG=/mnt/d/secrets/kube/config
 - **Small change** (values, ingress tweaks): edit → commit → sync that app.
 - **Wide change** (multiple apps): edit → commit → sync parent app (`oke-observability-stack`).
 - If Argo “looks stuck”: check `.status.conditions` and use hard refresh.
-
 

--- a/k8s/argocd-rbac-config.yaml
+++ b/k8s/argocd-rbac-config.yaml
@@ -21,7 +21,12 @@ data:
     p, role:admin, accounts, *, *, allow
     p, role:admin, gpgkeys, *, *, allow
     p, role:admin, certificates, *, *, allow
+
+    # Local bootstrap admin. Keep until SSO and break-glass recovery are proven.
     g, admin, role:admin
+
+    # Add the approved OIDC admin group here during the SSO cutover, for example:
+    # g, <approved-oidc-admin-group>, role:admin
 
   # Default role for all users
   policy.default: role:readonly

--- a/reports/2026-05-28-signalforge-oke-findings-infisical-triage.html
+++ b/reports/2026-05-28-signalforge-oke-findings-infisical-triage.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SignalForge OKE Findings And Infisical Migration Triage</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #101318;
+      --panel: #181c23;
+      --panel-2: #202631;
+      --ink: #f2efe7;
+      --muted: #b7b2a7;
+      --line: #343b48;
+      --accent: #d2a95f;
+      --info: #94b7dc;
+      --good: #8ccf91;
+      --warn: #e5b45e;
+      --bad: #e07b73;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: #101318;
+      color: var(--ink);
+      font-family: var(--sans);
+      line-height: 1.55;
+    }
+    .shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 54px; }
+    .topbar { color: var(--muted); display: flex; justify-content: space-between; gap: 16px; margin-bottom: 22px; }
+    .hero, .section, .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+    .hero { padding: 30px; margin-bottom: 16px; }
+    h1, h2, h3 { margin: 0; line-height: 1.14; letter-spacing: 0; }
+    h1 { max-width: 860px; font-size: clamp(2rem, 4vw, 4.3rem); }
+    h2 { font-size: 1.35rem; margin-bottom: 10px; }
+    h3 { font-size: 1rem; margin: 0 0 8px; }
+    p { color: var(--muted); margin: 10px 0 0; }
+    a { color: var(--accent); }
+    nav { display: flex; gap: 8px; flex-wrap: wrap; margin: 16px 0; }
+    nav a {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 7px 10px;
+      color: var(--ink);
+      text-decoration: none;
+      background: #151922;
+      font-size: 0.92rem;
+    }
+    .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; }
+    .section { grid-column: span 12; padding: 22px; scroll-margin-top: 20px; }
+    .span-4 { grid-column: span 4; }
+    .span-6 { grid-column: span 6; }
+    .card { padding: 16px; background: var(--panel-2); }
+    .label { color: var(--muted); text-transform: uppercase; letter-spacing: .08em; font-size: .76rem; font-weight: 800; }
+    .value { margin-top: 6px; font-size: 1.08rem; font-weight: 760; }
+    .status { display: inline-flex; align-items: center; gap: 8px; font-weight: 800; }
+    .status::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
+    .good { color: var(--good); }
+    .warn { color: var(--warn); }
+    .bad { color: var(--bad); }
+    .info { color: var(--info); }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    th, td { border-bottom: 1px solid var(--line); padding: 10px 8px; text-align: left; vertical-align: top; }
+    th { color: var(--muted); font-size: .78rem; text-transform: uppercase; letter-spacing: .06em; }
+    code, pre { font-family: var(--mono); }
+    code { color: #f0d08b; }
+    pre { overflow-x: auto; padding: 14px; border-radius: 8px; background: #0c0f14; border: 1px solid var(--line); }
+    ul, ol { color: var(--muted); }
+    li + li { margin-top: 6px; }
+    .note { border-left: 3px solid var(--accent); padding-left: 12px; color: var(--muted); }
+    @media (max-width: 820px) { .span-4, .span-6 { grid-column: span 12; } .topbar { flex-direction: column; } }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <div class="topbar">
+      <div>GrafanaLocal / central-observability-hub-stack</div>
+      <div>Generated 2026-05-28</div>
+    </div>
+
+    <section class="hero">
+      <div class="label">Read-only triage</div>
+      <h1>SignalForge OKE Findings And Infisical Migration Path</h1>
+      <p>This report separates the current SignalForge OKE findings from the Argo CD auth prep PR. It recommends source-backed hardening and a metadata-first path for moving OKE-related secrets to Infisical without handling secret values.</p>
+    </section>
+
+    <nav>
+      <a href="#verdict">Verdict</a>
+      <a href="#evidence">Evidence</a>
+      <a href="#findings">Findings</a>
+      <a href="#infisical">Infisical Path</a>
+      <a href="#next">Next Actions</a>
+      <a href="#boundaries">Boundaries</a>
+    </nav>
+
+    <section id="verdict" class="section">
+      <h2>Verdict</h2>
+      <div class="grid">
+        <div class="card span-4">
+          <div class="label">Current state</div>
+          <div class="value status warn">Baseline hardening backlog</div>
+          <p>The stale privileged debug pod was already deleted and independently verified. The remaining SignalForge findings are real posture items, but not evidence of a new outage or compromise.</p>
+        </div>
+        <div class="card span-4">
+          <div class="label">Best next fix</div>
+          <div class="value">Argo CD auth prep PR</div>
+          <p>Public Argo CD plus broad controller permissions makes SSO/local-admin hardening the highest leverage source-only improvement.</p>
+        </div>
+        <div class="card span-4">
+          <div class="label">Secret migration</div>
+          <div class="value status info">Plan only</div>
+          <p>OKE secret migration should start with metadata inventory and source-of-truth decisions. No kubeconfig, token, private key, or OAuth value should be moved without a separate approval gate.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="evidence" class="section">
+      <h2>Evidence Used</h2>
+      <table>
+        <thead><tr><th>Check</th><th>Result</th><th>Boundary</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>SignalForge health</td>
+            <td><code>https://signalforge.canepro.me/api/health</code> returned <code>ok=true</code>, provider <code>codex_app_server</code>, model <code>gpt-5.4</code>, transport <code>websocket</code>.</td>
+            <td>Public health only; no secrets.</td>
+          </tr>
+          <tr>
+            <td>OKE wrapper signals</td>
+            <td><code>signalforge-diagnostic-oke-prod-eu1.sh signals 5</code> returned <code>{"signals":[]}</code>.</td>
+            <td>Cheap check; no diagnostic queued.</td>
+          </tr>
+          <tr>
+            <td>Latest post-cleanup OKE diagnostic</td>
+            <td>Run <code>6d992fe9-917a-4cf1-b560-ef4bfe33b430</code>, request <code>ae4f9dee-2e54-4738-93e2-e58da2eccd39</code>, status <code>complete</code>, severity counts <code>critical=0 high=59 medium=168 low=0</code>.</td>
+            <td>Previously queued for explicit proof; helper restored to idle.</td>
+          </tr>
+          <tr>
+            <td>Existing Selene reports</td>
+            <td>Reviewed OKE security triage, GitOps ownership map, and all-source SignalForge cheap signals retest under <code>/Users/canepro/src/velora-infra/reports/selene/verification/</code>.</td>
+            <td>Report review only.</td>
+          </tr>
+          <tr>
+            <td>Infisical governance</td>
+            <td>Reviewed <code>/Users/canepro/src/velora-infra/runbooks/secrets-management-migration.md</code>, <code>ops/infisical-consumer-map.yaml</code>, and <code>/Users/canepro/src/signalforge/docs/infisical-secrets.md</code>.</td>
+            <td>Metadata and docs only; no value commands.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="findings" class="section">
+      <h2>SignalForge Findings Triage</h2>
+      <table>
+        <thead><tr><th>Finding</th><th>Assessment</th><th>Recommended path</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>External LoadBalancer for ingress-nginx</td>
+            <td>Expected public ingress pattern for this OKE hub. It should be treated as accepted exposure only after host-by-host policy is documented.</td>
+            <td>Source-backed exposure review. Do not change DNS, firewall, ingress, or public access in this PR.</td>
+          </tr>
+          <tr>
+            <td><code>system:masters</code> cluster-admin binding</td>
+            <td>Common Kubernetes bootstrap pattern, but the blast radius depends on who can authenticate into that group.</td>
+            <td>Read-only identity/kubeconfig inventory first. No blind RBAC deletion.</td>
+          </tr>
+          <tr>
+            <td><code>admin</code>/<code>edit</code> impersonation class</td>
+            <td>Known Kubernetes privilege-escalation class. Existing Selene map did not find broad live bindings to <code>admin</code>/<code>edit</code>, so this is audit backlog, not an emergency mutation.</td>
+            <td>Inventory RoleBindings and ClusterRoleBindings; reduce only source-backed bindings with owner/rollback known.</td>
+          </tr>
+          <tr>
+            <td>Argo CD wildcard roles</td>
+            <td>Operationally normal for Argo CD, but high blast radius because Argo CD is public and local admin is enabled.</td>
+            <td>Complete Argo CD auth prep first. Then review AppProject scoping and controller/server RBAC separately.</td>
+          </tr>
+          <tr>
+            <td>No NetworkPolicies</td>
+            <td>Real hardening gap. Risk depends on CNI policy support and workload traffic requirements.</td>
+            <td>Draft namespace-by-namespace policy plan. Stage default-deny carefully after traffic inventory.</td>
+          </tr>
+          <tr>
+            <td>No LimitRanges in key namespaces</td>
+            <td>Reliability and cost-control backlog, lower urgency than auth/RBAC.</td>
+            <td>Add namespace defaults after workload requests/limits inventory.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="infisical" class="section">
+      <h2>Safe Path To Migrate OKE Cluster Secrets To Infisical</h2>
+      <p class="note">This is a metadata-first plan. It does not approve reading, copying, staging, rotating, injecting, exporting, or committing secret values.</p>
+      <ol>
+        <li><strong>Define OKE secret classes:</strong> kubeconfigs, Argo CD OIDC client secret, External Secrets/OCI Vault material, SignalForge source-bound automation-agent token, CI/CD deploy credentials, and break-glass credentials.</li>
+        <li><strong>Record metadata only:</strong> secret name, consumer, current store, target Infisical project/environment/path, owner, rotation method, rollback path, and whether the current runtime depends on SOPS, OCI Vault, or Kubernetes Secret shape.</li>
+        <li><strong>Choose target layout:</strong> keep SignalForge app secrets aligned with the SignalForge repo contract; place OKE platform secrets under a separate project/folder such as <code>canepro-secrets / prod / /platform/oke</code> or a dedicated OKE project if access boundaries need to be stricter.</li>
+        <li><strong>Start with non-authoritative parallel-run staging:</strong> approved rows can be copied to Infisical only after explicit value-handling approval. Existing consumers continue reading from their current source.</li>
+        <li><strong>Use source-bound names:</strong> automation-agent tokens should follow a source-specific pattern such as <code>SIGNALFORGE_AUTOMATION_AGENT_TOKEN_OKE_PROD_EU1</code>; Argo OIDC should use a clear name such as <code>ARGOCD_OIDC_CLIENT_SECRET</code>.</li>
+        <li><strong>Prove injection without printing values:</strong> use <code>infisical run -- ...</code> or a short-lived restrictive temp file only for approved smoke tests. Proof should be secret name present, HTTP status, source binding, token prefix/hash if intentionally exposed, or consumer success/failure.</li>
+        <li><strong>Cut over one consumer class at a time:</strong> OIDC client secret first is a reasonable low-surface candidate once provider and admin group are chosen. Kubeconfigs and break-glass credentials should be later because rollback and lockout risk are higher.</li>
+        <li><strong>Do not remove old sources until rollback is proven:</strong> keep OCI Vault/ESO, SOPS, kubeconfig files, and runtime secret paths authoritative until the new consumer path is verified and Vincent approves authority transfer.</li>
+      </ol>
+    </section>
+
+    <section id="next" class="section">
+      <h2>Recommended Next Actions</h2>
+      <table>
+        <thead><tr><th>Order</th><th>Action</th><th>Approval needed</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>Merge/review the source-only Argo CD auth prep PR after Terraform proof passes.</td><td>No live apply in the PR.</td></tr>
+          <tr><td>2</td><td>Decide identity provider, exact admin group, OIDC secret path, and lockout rollback plan.</td><td>Vincent decision.</td></tr>
+          <tr><td>3</td><td>Create an OKE secrets metadata inventory using the Infisical schema/governance pattern.</td><td>Metadata-only is safe; value movement is not.</td></tr>
+          <tr><td>4</td><td>Draft source-backed RBAC/AppProject and NetworkPolicy plans from the SignalForge findings.</td><td>Review before mutation.</td></tr>
+          <tr><td>5</td><td>Run separate approved cutovers for OIDC, Infisical staging, and any ingress/RBAC changes.</td><td>Separate approval per boundary.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="boundaries" class="section">
+      <h2>Hard Boundaries Preserved</h2>
+      <ul>
+        <li>No live Argo CD auth change.</li>
+        <li>No Terraform apply.</li>
+        <li>No secret creation, reading, copying, staging, exporting, rotating, or value handling.</li>
+        <li>No DNS, firewall, ingress, public exposure, or RBAC mutation.</li>
+        <li>No local admin disablement.</li>
+        <li>No new SignalForge collection was queued for this report; only cheap signals and public health were checked during report creation.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/terraform/argocd-auth.tf
+++ b/terraform/argocd-auth.tf
@@ -1,0 +1,77 @@
+# Argo CD authentication hardening controls.
+#
+# Defaults preserve the current live bootstrap posture. The safe cutover is:
+# 1. choose the identity provider and exact admin group;
+# 2. provision Secret argocd/${var.argocd_oidc_client_secret_name} key clientSecret;
+# 3. add the approved group mapping to k8s/argocd-rbac-config.yaml;
+# 4. enable OIDC and verify login/admin access;
+# 5. disable the local admin account in a separate approved change.
+
+variable "argocd_local_admin_enabled" {
+  description = "Whether the built-in Argo CD local admin account is enabled. Keep true until SSO login and break-glass recovery are proven."
+  type        = bool
+  default     = true
+}
+
+variable "argocd_oidc_enabled" {
+  description = "Enable Argo CD OIDC SSO config. Requires the client secret to already exist in the argocd namespace."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_oidc_name" {
+  description = "Display name for the Argo CD OIDC connector."
+  type        = string
+  default     = "OIDC"
+}
+
+variable "argocd_oidc_issuer_url" {
+  description = "OIDC issuer URL for Argo CD SSO."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = !var.argocd_oidc_enabled || length(trimspace(var.argocd_oidc_issuer_url)) > 0
+    error_message = "argocd_oidc_issuer_url must be set when argocd_oidc_enabled is true."
+  }
+}
+
+variable "argocd_oidc_client_id" {
+  description = "OIDC client ID for Argo CD SSO. This is not a secret."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = !var.argocd_oidc_enabled || length(trimspace(var.argocd_oidc_client_id)) > 0
+    error_message = "argocd_oidc_client_id must be set when argocd_oidc_enabled is true."
+  }
+}
+
+variable "argocd_oidc_client_secret_name" {
+  description = "Kubernetes Secret name in namespace argocd containing key clientSecret for the Argo CD OIDC client."
+  type        = string
+  default     = "argocd-oidc-client-secret"
+}
+
+variable "argocd_oidc_requested_scopes" {
+  description = "OIDC scopes requested by Argo CD. Keep groups when RBAC maps provider groups."
+  type        = list(string)
+  default     = ["openid", "profile", "email", "groups"]
+}
+
+locals {
+  argocd_cm_base = {
+    "admin.enabled" = tostring(var.argocd_local_admin_enabled)
+    "url"           = "https://argocd.canepro.me"
+  }
+
+  argocd_cm_oidc = var.argocd_oidc_enabled ? {
+    "oidc.config" = yamlencode({
+      name            = var.argocd_oidc_name
+      issuer          = var.argocd_oidc_issuer_url
+      clientID        = var.argocd_oidc_client_id
+      clientSecret    = format("$%s:clientSecret", var.argocd_oidc_client_secret_name)
+      requestedScopes = var.argocd_oidc_requested_scopes
+    })
+  } : {}
+}

--- a/terraform/argocd.tf
+++ b/terraform/argocd.tf
@@ -12,6 +12,9 @@ resource "helm_release" "argocd" {
       global = {
         domain = "argocd.canepro.me"
       }
+      configs = {
+        cm = merge(local.argocd_cm_base, local.argocd_cm_oidc)
+      }
       server = {
         metrics   = { enabled = true }
         extraArgs = ["--insecure"]


### PR DESCRIPTION
## Summary

- add source-only Argo CD auth hardening controls for local admin and future OIDC
- document the real RBAC cutover point in `k8s/argocd-rbac-config.yaml`, because RBAC is deployed by the separate `argocd-rbac` Argo CD app rather than Terraform
- replace unsafe docs that taught printing the initial Argo CD admin password into transcripts
- add a separate read-only SignalForge OKE findings and Infisical migration triage report

## Hard stops preserved

This PR does **not**:

- apply Terraform
- change live Argo CD auth
- create, read, copy, stage, rotate, or print secret values
- change DNS, firewall, ingress, public exposure, or Kubernetes RBAC
- disable the local Argo CD admin account

## Verification

```text
terraform -chdir=terraform fmt -check -diff
terraform -chdir=terraform init -backend=false -input=false
terraform -chdir=terraform validate

git diff --cached --check
```

Results:

- Terraform fmt passed
- Terraform init with backend disabled passed
- Terraform validate passed: `Success! The configuration is valid.`
- staged diff whitespace check passed

## Notes

The OIDC client secret is referenced by Kubernetes Secret name/key only: `argocd/argocd-oidc-client-secret`, key `clientSecret`. The value is intentionally not committed or handled here.

The SignalForge triage is read-only and includes a safe metadata-first path for OKE cluster secrets migration to Infisical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runbook and handover guides with clarified local admin account policies and SSO cutover procedures.

* **New Features**
  * Added support for OIDC/SSO authentication configuration with ordered cutover sequence.
  * Added security findings report and migration recommendations.

* **Infrastructure**
  * Updated access control policies to support OIDC admin group mapping.
  * Enhanced infrastructure configuration to manage local admin account state and SSO enablement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canepro/central-observability-hub-stack/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->