### PR TITLE
Enable Entra OIDC for Argo CD

### DIFF
--- a/GITOPS-HANDOVER.md
+++ b/GITOPS-HANDOVER.md
@@ -33,6 +33,14 @@ add the approved admin group to `k8s/argocd-rbac-config.yaml`, enable OIDC in
 Terraform, prove login/admin access, then disable local admin in a separate
 approved change.
 
+Current SSO target:
+- Provider: Microsoft Entra ID.
+- Tenant ID: `040f4d47-c5be-488d-a48b-4b43fe04cac4`.
+- Client ID: `e1b5f345-dbd8-4e1e-a138-1c8fdb91fed9`.
+- Redirect URI: `https://argocd.canepro.me/auth/callback`.
+- Admin group: `ArgoCD OKE Admins` (`96a9bc27-c2d0-467c-a4ec-350ed00c653d`).
+- OIDC client secret: staged in Infisical `canepro-secrets/prod:/platform/oke/argocd` as `ARGOCD_OIDC_CLIENT_SECRET` and present in Kubernetes as `argocd/argocd-oidc-client-secret` key `clientSecret`.
+
 ## 📂 3. GitOps Configuration (Sources of Truth)
 
 | Repository | Branch | Path | Managed By |

--- a/hub-docs/ARGOCD-RUNBOOK.md
+++ b/hub-docs/ARGOCD-RUNBOOK.md
@@ -37,6 +37,20 @@ private operator shell, then rotate or disable the account after SSO is proven.
 6. Only after SSO and recovery access are proven, set
    `argocd_local_admin_enabled=false` in a separate approved change.
 
+### Current Entra SSO Configuration
+
+- Provider: Microsoft Entra ID
+- Tenant ID: `040f4d47-c5be-488d-a48b-4b43fe04cac4`
+- Issuer: `https://login.microsoftonline.com/040f4d47-c5be-488d-a48b-4b43fe04cac4/v2.0`
+- Argo CD app client ID: `e1b5f345-dbd8-4e1e-a138-1c8fdb91fed9`
+- Redirect URI: `https://argocd.canepro.me/auth/callback`
+- Admin group: `ArgoCD OKE Admins`
+- Admin group object ID: `96a9bc27-c2d0-467c-a4ec-350ed00c653d`
+- Secret staging path: Infisical `canepro-secrets/prod:/platform/oke/argocd`, key `ARGOCD_OIDC_CLIENT_SECRET`
+- Live Kubernetes secret: `argocd/argocd-oidc-client-secret`, key `clientSecret`
+
+Local admin remains enabled until SSO login and break-glass recovery are proven.
+
 ## How to think about updates
 
 - **Edit repo files** (`helm/*.yaml`, `k8s/*.yaml`, `argocd/applications/*.yaml`)
@@ -271,4 +285,3 @@ export KUBECONFIG=/mnt/d/secrets/kube/config
 - **Small change** (values, ingress tweaks): edit → commit → sync that app.
 - **Wide change** (multiple apps): edit → commit → sync parent app (`oke-observability-stack`).
 - If Argo “looks stuck”: check `.status.conditions` and use hard refresh.
-

--- a/k8s/argocd-rbac-config.yaml
+++ b/k8s/argocd-rbac-config.yaml
@@ -25,8 +25,8 @@ data:
     # Local bootstrap admin. Keep until SSO and break-glass recovery are proven.
     g, admin, role:admin
 
-    # Add the approved OIDC admin group here during the SSO cutover, for example:
-    # g, <approved-oidc-admin-group>, role:admin
+    # Microsoft Entra group: ArgoCD OKE Admins.
+    g, 96a9bc27-c2d0-467c-a4ec-350ed00c653d, role:admin
 
   # Default role for all users
   policy.default: role:readonly

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "3.1.1"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:47CqNwkxctJtL/N/JuEj+8QMg8mRNI/NWeKO5/ydfZU=",
     "h1:5b2ojWKT0noujHiweCds37ZreRFRQLNaErdJLusJN88=",
     "zh:1a6d5ce931708aec29d1f3d9e360c2a0c35ba5a54d03eeaff0ce3ca597cd0275",
     "zh:3411919ba2a5941801e677f0fea08bdd0ae22ba3c9ce3309f55554699e06524a",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 provider "registry.terraform.io/oracle/oci" {
   version = "7.31.0"
   hashes = [
+    "h1:5E0shLvUXFro+WZh4sxNDFy4FRyn6HUTah4oxOeFRoA=",
     "h1:xTOq7b4XMT8u6odPZfT4l0qV1r3Ti6AhkTye5uw98XQ=",
     "zh:1e9543b399109dfd66b95169579cf470d4482249b3379115b73fa3a7f2684c29",
     "zh:2915b76d376d9b2baca13bbf79680c73bea778c480f60ac87252c80a31043a79",

--- a/terraform/argocd-auth.tf
+++ b/terraform/argocd-auth.tf
@@ -16,19 +16,19 @@ variable "argocd_local_admin_enabled" {
 variable "argocd_oidc_enabled" {
   description = "Enable Argo CD OIDC SSO config. Requires the client secret to already exist in the argocd namespace."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "argocd_oidc_name" {
   description = "Display name for the Argo CD OIDC connector."
   type        = string
-  default     = "OIDC"
+  default     = "Microsoft Entra ID"
 }
 
 variable "argocd_oidc_issuer_url" {
   description = "OIDC issuer URL for Argo CD SSO."
   type        = string
-  default     = ""
+  default     = "https://login.microsoftonline.com/040f4d47-c5be-488d-a48b-4b43fe04cac4/v2.0"
 
   validation {
     condition     = !var.argocd_oidc_enabled || length(trimspace(var.argocd_oidc_issuer_url)) > 0
@@ -39,7 +39,7 @@ variable "argocd_oidc_issuer_url" {
 variable "argocd_oidc_client_id" {
   description = "OIDC client ID for Argo CD SSO. This is not a secret."
   type        = string
-  default     = ""
+  default     = "e1b5f345-dbd8-4e1e-a138-1c8fdb91fed9"
 
   validation {
     condition     = !var.argocd_oidc_enabled || length(trimspace(var.argocd_oidc_client_id)) > 0


### PR DESCRIPTION
## Summary
- enable Argo CD OIDC against Microsoft Entra ID while keeping local admin enabled
- map the Entra `ArgoCD OKE Admins` group to `role:admin`
- document the client ID, tenant, admin group, and Infisical/Kubernetes secret locations without secret values

## Live state already applied
- Entra app registration exists with redirect URI `https://argocd.canepro.me/auth/callback`
- OIDC client secret is staged in Infisical `canepro-secrets/prod:/platform/oke/argocd` as `ARGOCD_OIDC_CLIENT_SECRET`
- Kubernetes secret `argocd/argocd-oidc-client-secret` exists with key `clientSecret`
- Terraform applied `argocd-cm` OIDC config and local admin remains enabled

## Verification
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `AWS_REQUEST_CHECKSUM_CALCULATION=when_required AWS_RESPONSE_CHECKSUM_VALIDATION=when_required terraform plan -detailed-exitcode` returned no changes after state recovery
- `kubectl apply --dry-run=client -f k8s/argocd-rbac-config.yaml`
- `kubectl -n argocd rollout status deployment/argocd-server --timeout=120s`

## Guardrails
- no local admin disable
- no DNS/firewall/ingress change
- no secret value committed or printed
- no OCI infrastructure create/destroy
