### PR TITLE
Fix Entra OIDC requested scopes

### DIFF
--- a/hub-docs/ARGOCD-RUNBOOK.md
+++ b/hub-docs/ARGOCD-RUNBOOK.md
@@ -46,10 +46,13 @@ private operator shell, then rotate or disable the account after SSO is proven.
 - Redirect URI: `https://argocd.canepro.me/auth/callback`
 - Admin group: `ArgoCD OKE Admins`
 - Admin group object ID: `96a9bc27-c2d0-467c-a4ec-350ed00c653d`
+- Requested OIDC scopes: `openid`, `profile`, `email`
 - Secret staging path: Infisical `canepro-secrets/prod:/platform/oke/argocd`, key `ARGOCD_OIDC_CLIENT_SECRET`
 - Live Kubernetes secret: `argocd/argocd-oidc-client-secret`, key `clientSecret`
 
 Local admin remains enabled until SSO login and break-glass recovery are proven.
+Do not add `groups` to requested scopes for Entra; groups are emitted by the
+application's `groupMembershipClaims=SecurityGroup` setting.
 
 ## How to think about updates
 

--- a/terraform/argocd-auth.tf
+++ b/terraform/argocd-auth.tf
@@ -54,9 +54,9 @@ variable "argocd_oidc_client_secret_name" {
 }
 
 variable "argocd_oidc_requested_scopes" {
-  description = "OIDC scopes requested by Argo CD. Keep groups when RBAC maps provider groups."
+  description = "OIDC scopes requested by Argo CD. Entra emits groups as a token claim through groupMembershipClaims, not through a groups OAuth scope."
   type        = list(string)
-  default     = ["openid", "profile", "email", "groups"]
+  default     = ["openid", "profile", "email"]
 }
 
 locals {


### PR DESCRIPTION
## Summary
- remove the invalid `groups` OAuth scope from Argo CD Entra OIDC requested scopes
- document that Entra groups are emitted as token claims via `groupMembershipClaims=SecurityGroup`

## Verification
- `terraform fmt -check`
- `terraform validate`
- `terraform plan -out=/tmp/argocd-entra-scope-fix.tfplan` showed only removal of `groups` from `requestedScopes`
- `terraform apply -auto-approve /tmp/argocd-entra-scope-fix.tfplan`
- `terraform plan -detailed-exitcode` returned no changes
- `kubectl -n argocd rollout status deployment/argocd-server --timeout=120s`
- `kubectl -n argocd get cm argocd-cm` shows requested scopes `openid`, `profile`, `email`
- `curl https://argocd.canepro.me/auth/login` shows the authorize scope no longer requests `groups`

## Guardrails
- local admin remains enabled
- no secret changes
- no DNS/firewall/ingress changes
