### PR TITLE
Document Argo OIDC secret requirements

### DIFF
--- a/hub-docs/ARGOCD-RUNBOOK.md
+++ b/hub-docs/ARGOCD-RUNBOOK.md
@@ -53,6 +53,10 @@ private operator shell, then rotate or disable the account after SSO is proven.
 Local admin remains enabled until SSO login and break-glass recovery are proven.
 Do not add `groups` to requested scopes for Entra; groups are emitted by the
 application's `groupMembershipClaims=SecurityGroup` setting.
+The live Kubernetes secret must have label `app.kubernetes.io/part-of=argocd`
+so Argo CD resolves `$argocd-oidc-client-secret:clientSecret`. Write the value
+without a trailing newline; otherwise Entra rejects the token exchange with
+`AADSTS7000215`.
 
 ## How to think about updates
 


### PR DESCRIPTION
## Summary
- document the required `app.kubernetes.io/part-of=argocd` label for dedicated Argo OIDC secret references
- document that the Entra client secret value must be written without a trailing newline

## Live fix already applied
- rotated the Entra client secret
- updated Infisical `canepro-secrets/prod:/platform/oke/argocd` key `ARGOCD_OIDC_CLIENT_SECRET`
- updated Kubernetes secret `argocd/argocd-oidc-client-secret` key `clientSecret`
- labelled the secret with `app.kubernetes.io/part-of=argocd`
- restarted `argocd-server`

## Verification
- Kubernetes secret has the required label and key
- `argocd-cm` references `$argocd-oidc-client-secret:clientSecret`
- public login URL requests `openid+profile+email+offline_access`
- no secret value printed or committed
