### PR TITLE
Disable Argo CD local admin

### DIFF
--- a/GITOPS-HANDOVER.md
+++ b/GITOPS-HANDOVER.md
@@ -23,10 +23,11 @@ Notes:
 - The old cluster `k8-canepro-rocketchat` has been retired/deleted.
 
 ### 🔑 ArgoCD Access Posture
-The local `admin` account is bootstrap/break-glass only. Do not paste the
-initial admin password into chat, reports, tickets, logs, or shell transcripts.
-Retrieve it only in a private operator shell when emergency recovery requires
-it, then rotate or disable the account after SSO is proven.
+The local `admin` account is bootstrap/break-glass only and should be disabled
+in normal operation. Do not paste the initial admin password into chat, reports,
+tickets, logs, or shell transcripts. Retrieve it only in a private operator
+shell when emergency recovery requires it, then rotate and disable the account
+again after recovery.
 
 SSO cutover must happen in this order: provision OIDC app and client secret,
 add the approved admin group to `k8s/argocd-rbac-config.yaml`, enable OIDC in

--- a/hub-docs/ARGOCD-ENTRA-OIDC-CUTOVER.md
+++ b/hub-docs/ARGOCD-ENTRA-OIDC-CUTOVER.md
@@ -1,8 +1,8 @@
 # Argo CD Entra OIDC Cutover Runbook
 
 This public-safe runbook captures the repeatable path used to move Argo CD from
-local admin-only access to Microsoft Entra OIDC while keeping local admin as
-break-glass until SSO is proven.
+local admin-only access to Microsoft Entra OIDC, prove SSO, and then disable the
+local admin account in a separate change.
 
 Because this repository is public, keep secret values and private operational
 metadata out of this file. The source manifests necessarily contain non-secret
@@ -22,14 +22,14 @@ human-account details here.
 
 ## Safety Boundary
 
-- Keep `argocd_local_admin_enabled=true` until SSO login and admin access are
-  proven in the browser.
+- Keep `argocd_local_admin_enabled=true` only until SSO login and admin access
+  are proven in the browser.
 - Do not print, commit, paste, screenshot, or log the Entra client secret value.
 - Store the client secret in the approved secret manager and inject it into
   Kubernetes without exposing the value.
 - Do not change DNS, firewall, ingress, or local admin disablement in the same
   change as initial SSO enablement.
-- Treat disabling local admin as a later PR after rollback access is clear.
+- Treat disabling local admin as a separate PR after rollback access is clear.
 
 ## Source Files
 
@@ -211,7 +211,7 @@ Fix:
   `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required`
 - verify a follow-up plan is clean
 
-## Disable Local Admin Later
+## Disable Local Admin
 
 Only after successful SSO login and admin access are proven:
 
@@ -221,4 +221,5 @@ Only after successful SSO login and admin access are proven:
 4. Apply and verify local admin is disabled.
 
 Do not bundle local admin disablement with secret rotation, Entra app changes,
-DNS, ingress, firewall, or unrelated GitOps changes.
+DNS, ingress, firewall, or unrelated GitOps changes. After apply, verify
+`argocd-cm` has `admin.enabled=false` and browser SSO still works.

--- a/hub-docs/ARGOCD-RUNBOOK.md
+++ b/hub-docs/ARGOCD-RUNBOOK.md
@@ -11,12 +11,13 @@ All applications are managed by Argo CD with `prune: true` and `selfHeal: true`.
 
 ### Local Admin And SSO Posture
 
-The built-in `admin` account is a bootstrap and break-glass control. Keep it
-enabled until SSO login, admin group mapping, and recovery access are proven.
+The built-in `admin` account is a bootstrap control. It should stay disabled in
+normal operation now that SSO login, admin group mapping, and recovery access
+have been proven.
 
 Do not paste the initial admin password into chat, reports, tickets, logs, or
 shell transcripts. If emergency recovery requires it, retrieve it only in a
-private operator shell, then rotate or disable the account after SSO is proven.
+private operator shell, then rotate and disable the account again after recovery.
 
 ### SSO Cutover Sequence
 
@@ -47,7 +48,7 @@ The active non-secret Entra settings are in `terraform/argocd-auth.tf` and
 storage paths, secret IDs, human-account details, and raw credential material
 out of committed docs.
 
-Local admin remains enabled until SSO login and break-glass recovery are proven.
+Local admin is disabled after SSO login and break-glass recovery were proven.
 Do not add `groups` to requested scopes for Entra; groups are emitted by the
 application's `groupMembershipClaims=SecurityGroup` setting.
 The live Kubernetes secret must have label `app.kubernetes.io/part-of=argocd`

--- a/terraform/argocd-auth.tf
+++ b/terraform/argocd-auth.tf
@@ -10,7 +10,7 @@
 variable "argocd_local_admin_enabled" {
   description = "Whether the built-in Argo CD local admin account is enabled. Keep true until SSO login and break-glass recovery are proven."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "argocd_oidc_enabled" {


### PR DESCRIPTION
## Summary
- disable the built-in Argo CD local admin account now that Entra SSO has been proven in browser
- update public docs to describe local admin as disabled in normal operation
- keep OIDC, Entra group RBAC, ingress, DNS, firewall, and secrets unchanged

## Live apply already completed
- Applied saved Terraform plan `/tmp/argocd-disable-local-admin.tfplan` after confirming it only changed `configs.cm.admin.enabled` from `true` to `false`
- `argocd-server` rollout completed successfully

## Verification
- `terraform fmt -check`
- `terraform validate`
- `terraform plan -out=/tmp/argocd-disable-local-admin.tfplan` showed only the local admin flag flip
- `terraform apply -auto-approve /tmp/argocd-disable-local-admin.tfplan`
- follow-up `terraform plan -detailed-exitcode` returned no changes
- `kubectl -n argocd get cm argocd-cm` shows `admin.enabled=false` and OIDC still present
- `kubectl -n argocd get cm argocd-rbac-cm` still has Entra admin group mapping and `scopes: [groups]`
- `curl https://argocd.canepro.me/auth/login` still redirects with valid Entra scopes
- `curl https://argocd.canepro.me/api/version` succeeds

## Guardrails
- no secret rotation or value handling
- no Entra app changes
- no DNS/firewall/ingress changes
- no unrelated GitOps changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ArgoCD admin account security guidance covering emergency recovery procedures, SSO integration and cutover processes, and account management during normal operations with clear post-recovery actions.

* **Configuration Changes**
  * ArgoCD local admin account is now disabled by default, requiring explicit enablement when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canepro/central-observability-hub-stack/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->