### PR TITLE
Add OKE Infisical migration plan

### DIFF
--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -164,17 +164,11 @@ When you see an alert firing in Grafana (*Alerting* -> *Alert rules*), use `docs
 
 ## 8. Maintenance & Secret Restoration
 
-In the event of a cluster rebuild, the SMTP secret must be restored manually to re-enable notifications:
-
-```bash
-# Run on the OKE Cluster
-kubectl create secret generic grafana-smtp-credentials \
-  --from-literal=password='your-app-password' \
-  --from-literal=user='your-email@gmail.com' \
-  --from-literal=from_address='your-email@gmail.com' \
-  --from-literal=to_address='your-email@gmail.com' \
-  -n monitoring
-```
+In the event of a cluster rebuild, restore the SMTP secret through the approved
+secret store and sync it back into `monitoring/grafana-smtp-credentials`.
+Manual `kubectl create secret --from-literal=...` commands are intentionally
+not documented here because this repo is public and those commands encourage
+credential exposure in terminals and transcripts.
 
 **Note**: All SMTP credentials (password, user, from_address, to_address) are stored in the secret to avoid exposing PII in the public repository.
 
@@ -192,17 +186,9 @@ If `from_address` / `user` are missing, Grafana may fail to start with `CreateCo
 
 ### Safe update / rotation (no delete)
 
-Use `apply` to upsert values (recommended when rotating passwords):
-
-```bash
-# Run on the OKE Cluster
-kubectl -n monitoring create secret generic grafana-smtp-credentials \
-  --from-literal=password='NEW_APP_PASSWORD' \
-  --from-literal=user='your-email@gmail.com' \
-  --from-literal=from_address='your-email@gmail.com' \
-  --from-literal=to_address='your-email@gmail.com' \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
+Rotate values in the source secret store, then verify Kubernetes only by key
+shape and rollout status. Do not paste SMTP values into shell history or shared
+logs.
 
 Verify the keys:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,11 +24,9 @@ This guide provides step-by-step instructions for connecting your applications t
 
 1. **URL**: https://grafana.canepro.me (HTTPS enabled)
 2. **Username**: `admin`
-3. **Password**: Run to retrieve:
-   ```bash
-   kubectl -n monitoring get secret grafana \
-     -o jsonpath="{.data.admin-password}" | base64 -d ; echo
-   ```
+3. **Password**: use the approved operator credential path. Do not decode or
+   paste the Kubernetes Secret value into shared terminals, tickets, reports, or
+   PR comments.
    (Source: External Secrets Operator syncs from OCI Vault into `grafana`)
 
 ### Change Admin Password
@@ -40,13 +38,10 @@ This guide provides step-by-step instructions for connecting your applications t
 3. Go to "Change Password"
 4. Enter current and new password
 
-**Or via CLI**:
-```bash
-kubectl exec -n monitoring deployment/grafana -- \
-  grafana-cli admin reset-admin-password <new-password>
-```
-
-**Credential source of truth**: Update the JSON secret in OCI Vault (keys: `admin_password`, `secret_key`). ESO refreshes the Kubernetes secret automatically.
+**Credential source of truth**: rotate the JSON secret in the approved secret
+store (keys: `admin_password`, `secret_key`). ESO refreshes the Kubernetes
+secret automatically. Avoid CLI password resets because they drift from the
+declared source of truth.
 
 ### Configure Loki Datasource
 
@@ -192,10 +187,11 @@ If you use server-side tools that read logs directly from Loki (for example Rock
 - Query path used by clients: `/loki/api/v1/query_range` (and optionally `/loki/api/v1/query`)
 - Auth: same Basic Auth credentials used for ingress
 
-Example validation from a workstation:
+Example validation from a workstation, using a password from the approved
+operator credential path:
 
 ```bash
-curl -sS -u 'observability-user:YOUR_PASSWORD_HERE' -G \
+curl -sS -u 'observability-user:<redacted>' -G \
   'https://observability.canepro.me/loki/api/v1/query_range' \
   --data-urlencode 'query={job="rocketchat"}' \
   --data-urlencode 'limit=1'
@@ -331,7 +327,7 @@ const sdk = new NodeSDK({
   traceExporter: new OTLPTraceExporter({
     url: 'https://observability.canepro.me/v1/traces',
     headers: {
-      'Authorization': 'Basic ' + Buffer.from('observability-user:YOUR_PASSWORD').toString('base64')
+      'Authorization': 'Basic ' + Buffer.from(process.env.OBSERVABILITY_BASIC_AUTH).toString('base64')
     }
     // Note: Path /v1/traces corresponds to the Ingress rule
   }),

--- a/docs/MULTI-CLUSTER-SETUP-COMPLETE.md
+++ b/docs/MULTI-CLUSTER-SETUP-COMPLETE.md
@@ -208,7 +208,7 @@ helm upgrade --install promtail grafana/promtail \
   --namespace monitoring \
   --set config.clients[0].url=https://observability.canepro.me/loki/api/v1/push \
   --set config.clients[0].basic_auth.username=observability-user \
-  --set config.clients[0].basic_auth.password=50JjX+diU6YmAZPl
+  --set config.clients[0].basic_auth.password='<redacted>'
 ```
 
 ### 2. Add More Spoke Clusters

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,16 +6,11 @@
 
 **URL:** https://grafana.canepro.me (HTTPS enabled)
 
-**Login:**
-```bash
-Username: admin
-Password: (run command below)
+**Login:** use the approved operator credential path. Do not print the Grafana
+admin password into chat, tickets, shared terminals, reports, or PR comments.
 
-kubectl -n monitoring get secret grafana \
-  -o jsonpath="{.data.admin-password}" | base64 -d ; echo
-```
-
-**Note**: Admin credentials and Grafana `secret_key` are sourced from OCI Vault via External Secrets Operator into the `grafana` secret.
+**Note**: Admin credentials and Grafana `secret_key` are sourced from OCI Vault
+via External Secrets Operator into the `grafana` secret.
 
 **Note**: If HTTPS certificate errors occur, wait 2-3 minutes for certificate propagation or use HTTP fallback: http://grafana.canepro.me
 
@@ -257,11 +252,10 @@ kubectl delete pod alertmanager-prometheus-alertmanager-0 -n monitoring
 ## 🆘 Troubleshooting
 
 ### Grafana Login Issues
-```bash
-# Reset admin password
-kubectl exec -n monitoring deployment/grafana -- \
-  grafana-cli admin reset-admin-password newpassword
-```
+
+Rotate the source secret through the approved secret store, then allow External
+Secrets Operator to refresh `monitoring/grafana`. Avoid ad-hoc in-pod password
+resets because they drift from the declared source of truth.
 
 ### Can't Access Grafana
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -24,14 +24,13 @@ Common issues and solutions for the OKE observability stack deployment.
 2. **Wrong Hash Format**: NGINX Ingress `auth-type: basic` requires `htpasswd` format (MD5/APR1/Bcrypt), but some generated hashes (like default `openssl passwd`) might be incompatible or truncated.
 
 **Solution**:
-Always use **single quotes** when creating secrets via CLI to prevent variable expansion.
+If a temporary basic-auth Secret must be created manually, generate the
+`htpasswd` file outside shared terminals and apply it from a file. Avoid
+`--from-literal` with credential payloads in commands because those values often
+end up in shell history and transcripts.
 
 ```bash
-# BAD (Bash expands $apr1)
-kubectl create secret generic auth --from-literal=auth="user:$apr1$..."
-
-# GOOD (Single quotes)
-kubectl create secret generic auth --from-literal=auth='user:$apr1$...'
+kubectl create secret generic auth --from-file=auth -n monitoring
 ```
 
 ---
@@ -77,10 +76,10 @@ nginx.ingress.kubernetes.io/rewrite-target: /$1
    - `/loki/api/v1/query`
    - `/loki/api/v1/query_range`
 2. Commit the change and let ArgoCD sync `nginx-ingress` / manifests.
-3. Re-test with Basic Auth:
+3. Re-test with Basic Auth using the approved operator credential path:
 
 ```bash
-curl -sS -u 'observability-user:YOUR_PASSWORD_HERE' -G \
+curl -sS -u 'observability-user:<redacted>' -G \
   'https://observability.canepro.me/loki/api/v1/query_range' \
   --data-urlencode 'query={job="rocketchat"}' \
   --data-urlencode 'limit=1'
@@ -163,13 +162,16 @@ loki:
 **Fix pattern** (recommended):
 
 - Put credentials in a K8s Secret as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+- Prefer syncing that Secret from the approved secret store instead of creating
+  it manually on the cluster
 - Inject the secret via `extraEnvFrom`
 - Do **not** embed credentials in the Loki/Tempo config blocks; let the SDK read env vars.
 
+Verify the runtime shape without printing values:
+
 ```bash
-kubectl -n monitoring create secret generic loki-s3-credentials \
-  --from-literal=AWS_ACCESS_KEY_ID='...' \
-  --from-literal=AWS_SECRET_ACCESS_KEY='...'
+kubectl -n monitoring get secret loki-s3-credentials -o json |
+  jq '{name:.metadata.name, data_keys:(.data|keys)}'
 ```
 
 ### Grafana Loki dashboard error: `parse error ... unexpected IDENTIFIER`
@@ -363,16 +365,14 @@ It should be > 0.
 
 **Fix**
 1. Generate a new **Gmail App Password** for the account used to send alerts.
-2. Update the Secret (safe upsert, no delete):
+2. Rotate the value through the approved secret store and sync it back into
+   `monitoring/grafana-smtp-credentials`.
+3. Verify the Kubernetes Secret by key shape only:
 ```bash
-kubectl -n monitoring create secret generic grafana-smtp-credentials \
-  --from-literal=password='NEW_GMAIL_APP_PASSWORD' \
-  --from-literal=user='your-email@gmail.com' \
-  --from-literal=from_address='your-email@gmail.com' \
-  --from-literal=to_address='alerts-recipient@gmail.com' \
-  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n monitoring get secret grafana-smtp-credentials -o json |
+  jq '{name:.metadata.name, data_keys:(.data|keys)}'
 ```
-3. Restart Alertmanager (pods do not reload env vars automatically):
+4. Restart Alertmanager (pods do not reload env vars automatically):
 ```bash
 kubectl -n monitoring rollout restart statefulset/prometheus-alertmanager
 ```

--- a/docs/WORLD-TREE-ROADMAP-COMPLETE.md
+++ b/docs/WORLD-TREE-ROADMAP-COMPLETE.md
@@ -51,12 +51,10 @@ See `docs/external-config/KIND-SPOKE-SETUP.md` for complete instructions.
 
 Quick start:
 ```bash
-# 1. Create namespace and secret
+# 1. Create namespace and verify the secret shape
 kubectl create namespace monitoring
-kubectl create secret generic observability-credentials \
-  --from-literal=username="observability-user" \
-  --from-literal=password="YOUR_PASSWORD" \
-  -n monitoring
+kubectl get secret observability-credentials -n monitoring -o json |
+  jq '{name:.metadata.name, data_keys:(.data|keys)}'
 
 # 2. Deploy agent
 kubectl apply -f docs/external-config/prometheus-agent-kind-spoke.yaml

--- a/docs/external-config/KIND-SPOKE-SETUP.md
+++ b/docs/external-config/KIND-SPOKE-SETUP.md
@@ -30,25 +30,16 @@ kubectl create namespace monitoring
 
 ## Step 2: Create Credentials Secret
 
-You need the same credentials used in the Hub's `observability-auth` secret.
+Use the approved secret store or private operator runbook to provision the spoke
+`observability-credentials` secret. Do not retrieve or paste the hub
+`observability-auth` payload into public docs, chat, tickets, or shared logs.
+
+The spoke Secret must contain the same key shape expected by the Prometheus
+Agent config:
 
 ```bash
-# Create the secret with Basic Auth credentials
-kubectl create secret generic observability-credentials \
-  --from-literal=username="observability-user" \
-  --from-literal=password="YOUR_PASSWORD_HERE" \
-  -n monitoring
-```
-
-**Note**: Replace `YOUR_PASSWORD_HERE` with the actual password from your Hub's `observability-auth` secret.
-
-To retrieve the password from the Hub:
-```bash
-# Switch to Hub context
-kubectl config use-context <oke-context>
-
-# Get the password (if stored as plain text)
-kubectl get secret observability-auth -n monitoring -o jsonpath='{.data.auth}' | base64 -d
+kubectl -n monitoring get secret observability-credentials -o json |
+  jq '{name:.metadata.name, data_keys:(.data|keys)}'
 ```
 
 ## Step 3: Deploy Node Exporter (Optional but Recommended)

--- a/docs/external-config/ROCKETCHAT-SETUP.md
+++ b/docs/external-config/ROCKETCHAT-SETUP.md
@@ -6,14 +6,14 @@ Use these instructions to configure the `rocketchat-k8s` cluster (AKS, `k8.canep
 
 **Hub URL**: `https://observability.canepro.me`
 **Username**: `observability-user`
-**Password**: `YOUR_PASSWORD_HERE`
+**Password**: use the approved operator credential path
 
 ### Rocket.Chat Logs Viewer app settings (read path)
 
 If you install the Rocket.Chat marketplace app `Logs Viewer`, configure:
 - `loki_base_url`: `https://observability.canepro.me`
 - `loki_username`: `observability-user`
-- `loki_token`: `YOUR_PASSWORD_HERE`
+- `loki_token`: use the approved operator credential path
 
 Important:
 - The app is a **reader** and calls Loki query APIs (`/loki/api/v1/query_range`).
@@ -39,15 +39,14 @@ kubectl delete configmap prometheus-agent-config -n monitoring --ignore-not-foun
 ```
 
 ### Step 2: Create Observability Namespace & Secret
-Ensure the namespace exists and store the hub credentials.
+Ensure the namespace exists and store the hub credentials through the approved
+secret store or a private operator runbook.
 
 ```bash
 kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
 
-kubectl create secret generic observability-credentials -n monitoring \
-  --from-literal=username="observability-user" \
-  --from-literal=password="YOUR_PASSWORD_HERE" \
-  --dry-run=client -o yaml | kubectl apply -f -
+kubectl get secret observability-credentials -n monitoring -o json |
+  jq '{name:.metadata.name, data_keys:(.data|keys)}'
 ```
 
 ### Step 3: Deploy Prometheus Agent
@@ -72,7 +71,7 @@ promtail:
       - url: https://observability.canepro.me/loki/api/v1/push
         basic_auth:
           username: observability-user
-          password: YOUR_PASSWORD_HERE
+          password: <redacted>
 ```
 
 **Apply via Helm:**

--- a/hub-docs/JENKINS-SPLIT-AGENT-PLAN.md
+++ b/hub-docs/JENKINS-SPLIT-AGENT-PLAN.md
@@ -242,8 +242,9 @@ After Jenkins is up, you need the **agent connection secret** for the **aks-agen
 
 - **Controller:** Running at **https://jenkins-oke.canepro.me** (OKE, namespace `jenkins`).
 - **TLS:** Certificate `jenkins-oke-tls` is **Ready**; HTTPS works.
-- **Login:** Admin password from secret:  
-  `kubectl get secret -n jenkins jenkins -o jsonpath='{.data.jenkins-admin-password}' | base64 -d; echo`
+- **Login:** use the approved operator credential path. Do not decode the
+  Jenkins admin password into shared terminals, tickets, reports, or PR
+  comments.
 - **aks-agent node:** Defined in JCasC (inbound launcher). Agent secret for Phase 2: **Manage Jenkins → Nodes → aks-agent → Connect** (or `/computer/aks-agent/`).
 - **Next:** Phase 2 — connect the AKS static agent with `-webSocket` to `https://jenkins-oke.canepro.me`.
 

--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -1,0 +1,127 @@
+# OKE Infisical Secrets Migration
+
+This public repo records the GitOps contract only. Do not commit secret values,
+private paths, kubeconfigs, OAuth state, token IDs, screenshots of credentials,
+or operator-specific Infisical metadata here.
+
+## Current Secret Delivery
+
+The OKE hub currently uses a mixed model:
+
+| Class | Current delivery | GitOps consumer | Migration posture |
+| --- | --- | --- | --- |
+| Grafana admin and `secret_key` | External Secrets Operator from OCI Vault | `monitoring/grafana` and `helm/grafana-values.yaml` | Keep live path until an Infisical-backed ESO store is proven |
+| Jenkins admin | External Secrets Operator from OCI Vault | `jenkins/jenkins-admin-credentials` and `helm/jenkins-values.yaml` | Candidate for staged Infisical mirror, then source cutover |
+| Jenkins GitHub token | External Secrets Operator from OCI Vault | `jenkins/github-token` and Jenkins credentials provider | Candidate after token owner, scope, and rotation path are confirmed |
+| PipelineHealer Jenkins bridge values | External Secrets Operator from OCI Vault | `jenkins/pipelinehealer-bridge-*` | Candidate after PipelineHealer consumer smoke is defined |
+| Argo CD OIDC client secret | Manual Kubernetes Secret referenced by Argo CD | `argocd/argocd-oidc-client-secret` and `terraform/argocd-auth.tf` | Good first OKE cutover candidate; low shape complexity, clear rollback |
+| Grafana SMTP credentials | Manual Kubernetes Secret | `monitoring/grafana-smtp-credentials`, Grafana, Alertmanager | Candidate after mail owner and app-password rotation path are confirmed |
+| Loki/Tempo S3 credentials | Manual Kubernetes Secret | `monitoring/loki-s3-credentials`, Loki, Tempo | Candidate after object-storage access key scope and rollback are confirmed |
+| Observability basic auth | Manual Kubernetes Secret | `monitoring/observability-auth`, remote-write clients | Higher blast radius; migrate after spoke cutover plan exists |
+| TLS and cert-manager secrets | Controller-managed Kubernetes Secrets | cert-manager, ingress controllers | Leave controller-owned; do not migrate values to Infisical |
+| Helm release secrets | Helm internal state | Helm/Argo CD | Leave unmanaged by Infisical |
+| Argo repo and cluster credentials | Argo-managed Kubernetes Secrets | Argo CD | Handle separately; may include stale or cross-cluster credentials |
+| SignalForge agent token and pull secret | Helm/manual Kubernetes Secrets | `signalforge-agent` | Coordinate through SignalForge/Selene runbook before value movement |
+
+## Target Model
+
+Use Infisical as the durable source for project/runtime/API/CI/service
+credentials. Keep Apple Passwords for human logins. Keep SOPS or controller
+ownership where an existing runtime contract depends on it.
+
+For OKE, the preferred live shape is:
+
+1. Store approved secret values in an Infisical project/environment/folder
+   selected in private operator notes.
+2. Sync those values into Kubernetes through a reviewed External Secrets path.
+3. Keep Kubernetes Secret names and keys stable so Helm, Terraform, and Argo CD
+   consumers do not need unrelated changes.
+4. Cut over one consumer class at a time.
+5. Keep the previous source available until rollback is proven.
+
+## Public-Safe Inventory Fields
+
+Public docs and PRs may include:
+
+- Kubernetes namespace and Secret name
+- expected key names
+- owning controller or consumer
+- current source class such as OCI Vault, manual Kubernetes Secret, Helm, or cert-manager
+- target store class such as Infisical via ESO
+- rollout and rollback steps
+- redacted proof shape
+
+Public docs and PRs must not include:
+
+- secret values or base64-decoded payloads
+- kubeconfig contents
+- private keys
+- token IDs or OAuth state
+- personal account details
+- private Infisical project IDs, service-token values, or local filesystem paths
+
+## Migration Order
+
+1. **Argo CD OIDC client secret**
+   - Target shape: keep `argocd/argocd-oidc-client-secret` with key
+     `clientSecret` and label `app.kubernetes.io/part-of=argocd`.
+   - Cutover method: make an ExternalSecret write the same Secret shape from
+     Infisical, restart `argocd-server`, prove Entra login and admin group
+     access, then remove the manual source.
+   - Rollback: restore the previous Kubernetes Secret shape and restart
+     `argocd-server`.
+
+2. **Grafana SMTP credentials**
+   - Target shape: keep `monitoring/grafana-smtp-credentials` with keys
+     `password`, `user`, `from_address`, and `to_address`.
+   - Cutover method: sync from Infisical, restart Grafana and Alertmanager,
+     prove alert notification config loads without printing values.
+   - Rollback: restore the previous Kubernetes Secret shape.
+
+3. **Jenkins OCI Vault-backed secrets**
+   - Target shape: keep existing Kubernetes Secret names and Jenkins credential
+     IDs.
+   - Cutover method: mirror one Jenkins credential family at a time, then switch
+     ESO source after Jenkins can still scan and run non-destructive jobs.
+   - Rollback: switch the ExternalSecret back to OCI Vault.
+
+4. **Loki/Tempo S3 credentials**
+   - Target shape: keep `monitoring/loki-s3-credentials` with the current AWS
+     SDK-compatible keys.
+   - Cutover method: sync from Infisical, restart Loki and Tempo, prove write
+     and read paths with status/health checks only.
+   - Rollback: restore previous Secret source.
+
+5. **Observability remote-write auth and SignalForge agent credentials**
+   - Target shape: keep current Secret names until all external consumers have a
+     matching cutover plan.
+   - Cutover method: coordinate through private operator notes because these
+     values affect cross-cluster and Selene/SignalForge workflows.
+
+## Redacted Verification
+
+Acceptable proof:
+
+```bash
+kubectl get externalsecrets -A
+kubectl get secret -n <namespace> <name> -o json |
+  jq '{name:.metadata.name, labels:.metadata.labels, data_keys:(.data|keys)}'
+kubectl rollout status deployment/<deployment> -n <namespace>
+```
+
+Do not use commands that decode or print secret payloads in PRs, tickets,
+handoffs, reports, or shared chat.
+
+## Approval Gates
+
+Metadata inventory, repo docs, and ExternalSecret shape reviews are safe.
+
+These actions need explicit current-task approval:
+
+- reading or copying a secret value from Kubernetes, OCI Vault, SOPS, local
+  files, or Infisical
+- creating or exporting Infisical service tokens
+- rotating provider-side credentials
+- making Infisical authoritative for a live consumer
+- deleting old secret sources
+- changing cross-cluster, SignalForge, or break-glass credential paths

--- a/hub-docs/OPERATIONS-HUB.md
+++ b/hub-docs/OPERATIONS-HUB.md
@@ -311,15 +311,10 @@ Scrapes use the service account CA for TLS verification (no `insecure_skip_verif
 - Source manifests: `k8s/external-secrets/` (ClusterSecretStore + ExternalSecret).
 
 ## 🔑 Grafana Admin Password Reset
-If you lose access to the Grafana UI, the preferred fix is to rotate the Vault secret (`admin_password`) so ESO refreshes the Kubernetes secret. If you must reset via CLI, update Vault afterward to avoid drift.
-
-```bash
-# 1. Get the pod name first
-POD_NAME=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana -o jsonpath="{.items[0].metadata.name}")
-
-# 2. Reset the 'admin' user password (e.g., to 'admin123')
-kubectl exec -n monitoring $POD_NAME -- grafana-cli admin reset-admin-password admin123
-```
+If you lose access to the Grafana UI, rotate the source secret
+(`admin_password`) through the approved secret store so ESO refreshes the
+Kubernetes Secret. Avoid in-pod password resets because they drift from the
+declared source of truth.
 
 ## 🧩 Grafana Rollouts (E1 vs PVC)
 


### PR DESCRIPTION
## Summary
- add a public-safe OKE Infisical secrets migration contract
- document current secret source classes, target migration order, redacted proof, and approval gates
- remove or replace docs that taught decoding or pasting secret values into terminals/transcripts

## Verification
- git diff --check
- targeted repo scan found no remaining unsafe public doc examples for base64-decoded secret payloads, literal placeholder passwords, or manual --from-literal password commands
- live OKE metadata inventory was keys-only: ExternalSecrets, ClusterSecretStore status, Secret names/types/labels/key names only

## Boundary
- metadata and docs only
- no secret values read, printed, committed, moved, rotated, or injected
- no live Kubernetes, Infisical, OCI Vault, DNS, ingress, or Terraform mutation

Private operator proof was saved outside this public repo at /Users/canepro/src/velora-infra/reports/security/2026-05-28-oke-infisical-migration-metadata-inventory.md.