### PR TITLE
Manage Argo OIDC secret from Infisical

### DIFF
--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -125,3 +125,18 @@ These actions need explicit current-task approval:
 - making Infisical authoritative for a live consumer
 - deleting old secret sources
 - changing cross-cluster, SignalForge, or break-glass credential paths
+
+## Argo OIDC Pilot
+
+The first live pilot keeps the existing Argo CD consumer contract and moves the
+source of `argocd/argocd-oidc-client-secret` to External Secrets Operator backed
+by Infisical:
+
+- store: `ClusterSecretStore/infisical-oke`
+- target: `argocd/argocd-oidc-client-secret`
+- key: `clientSecret`
+- required label: `app.kubernetes.io/part-of=argocd`
+
+Private operator notes own the Infisical auth material and any rollback value.
+Public proof should stay limited to store readiness, ExternalSecret readiness,
+target Secret key shape, Argo rollout status, and SSO/admin success.

--- a/k8s/external-secrets/argocd-oidc-client-secret-externalsecret.yaml
+++ b/k8s/external-secrets/argocd-oidc-client-secret-externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-oidc-client-secret
+  namespace: argocd
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke
+  target:
+    name: argocd-oidc-client-secret
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: argocd
+      data:
+        clientSecret: "{{ .clientSecret }}"
+  data:
+    - secretKey: clientSecret
+      remoteRef:
+        key: ARGOCD_OIDC_CLIENT_SECRET

--- a/k8s/external-secrets/clustersecretstore-infisical-oke.yaml
+++ b/k8s/external-secrets/clustersecretstore-infisical-oke.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical-oke
+spec:
+  provider:
+    infisical:
+      hostAPI: https://app.infisical.com/api
+      auth:
+        tokenAuthCredentials:
+          accessToken:
+            name: infisical-oke-auth
+            namespace: external-secrets
+            key: accessToken
+      secretsScope:
+        projectSlug: canepro-secrets
+        environmentSlug: prod
+        secretsPath: /platform/oke/argocd
+        recursive: false
+        expandSecretReferences: false


### PR DESCRIPTION
## Summary
- add an Infisical-backed `ClusterSecretStore` for the OKE Argo pilot
- add an `ExternalSecret` that preserves `argocd/argocd-oidc-client-secret` with key `clientSecret` and the required Argo label
- document the live Argo OIDC pilot in the public migration runbook

## Verification
- `kubectl apply --dry-run=server -f k8s/external-secrets/clustersecretstore-infisical-oke.yaml -f k8s/external-secrets/argocd-oidc-client-secret-externalsecret.yaml`
- `git diff --check`
- targeted secret-pattern scan of changed public files

## Boundary
- source contains only secret references and Infisical metadata, no secret values
- approved value path used privately: `copy_current_value` for `argocd/argocd-oidc-client-secret`
- current value was staged into Infisical without printing it
- ESO auth Secret exists as `external-secrets/infisical-oke-auth`, with only key shape reported

Post-merge verification will check store readiness, ExternalSecret readiness, target Secret key shape, Argo server rollout, and SSO/admin access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Argo OIDC Pilot section describing External Secrets Operator integration approach.

* **New Features**
  * Introduced Infisical-backed secret management for Argo CD OIDC client credentials through External Secrets Operator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canepro/central-observability-hub-stack/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->