### PR TITLE
Migrate existing ESO consumers to Infisical

### DIFF
--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -82,7 +82,10 @@ Public docs and PRs must not include:
    - Target shape: keep existing Kubernetes Secret names and Jenkins credential
      IDs.
    - Cutover method: mirror one Jenkins credential family at a time, then switch
-     ESO source after Jenkins can still scan and run non-destructive jobs.
+     ESO source after Jenkins can still scan and run non-destructive jobs. The
+     first source-backed cutover uses the scoped
+     `ClusterSecretStore/infisical-oke-jenkins` and preserves existing target
+     Secrets.
    - Rollback: switch the ExternalSecret back to OCI Vault.
 
 4. **Loki/Tempo S3 credentials**
@@ -140,3 +143,19 @@ by Infisical:
 Private operator notes own the Infisical auth material and any rollback value.
 Public proof should stay limited to store readiness, ExternalSecret readiness,
 target Secret key shape, Argo rollout status, and SSO/admin success.
+
+## Existing ESO Consumer Cutover
+
+After the Argo OIDC pilot, the next reviewed GitOps cutover moves existing OCI
+Vault-backed ESO consumers to Infisical while preserving their live Kubernetes
+Secret names and keys:
+
+- `monitoring/grafana`
+- `jenkins/jenkins-admin-credentials`
+- `jenkins/github-token`
+- `jenkins/pipelinehealer-bridge-secret`
+- `jenkins/pipelinehealer-bridge-url`
+
+The public repo contains only non-secret store names, folder paths, and remote
+key names. Private operator proof owns value staging, service-token creation,
+and rollback notes.

--- a/k8s/external-secrets/clustersecretstore-infisical-oke-jenkins.yaml
+++ b/k8s/external-secrets/clustersecretstore-infisical-oke-jenkins.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical-oke-jenkins
+spec:
+  provider:
+    infisical:
+      hostAPI: https://app.infisical.com/api
+      auth:
+        tokenAuthCredentials:
+          accessToken:
+            name: infisical-oke-jenkins-auth
+            namespace: external-secrets
+            key: accessToken
+      secretsScope:
+        projectSlug: canepro-secrets
+        environmentSlug: prod
+        secretsPath: /platform/oke/jenkins
+        recursive: false
+        expandSecretReferences: false

--- a/k8s/external-secrets/clustersecretstore-infisical-oke-monitoring.yaml
+++ b/k8s/external-secrets/clustersecretstore-infisical-oke-monitoring.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical-oke-monitoring
+spec:
+  provider:
+    infisical:
+      hostAPI: https://app.infisical.com/api
+      auth:
+        tokenAuthCredentials:
+          accessToken:
+            name: infisical-oke-monitoring-auth
+            namespace: external-secrets
+            key: accessToken
+      secretsScope:
+        projectSlug: canepro-secrets
+        environmentSlug: prod
+        secretsPath: /platform/oke/monitoring
+        recursive: false
+        expandSecretReferences: false

--- a/k8s/external-secrets/grafana-admin-externalsecret.yaml
+++ b/k8s/external-secrets/grafana-admin-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: oci-vault
+    name: infisical-oke-monitoring
   target:
     name: grafana
     creationPolicy: Owner
@@ -19,9 +19,7 @@ spec:
   data:
     - secretKey: admin-password
       remoteRef:
-        key: grafana-admin-json
-        property: admin_password
+        key: GRAFANA_ADMIN_PASSWORD
     - secretKey: secret_key
       remoteRef:
-        key: grafana-admin-json
-        property: secret_key
+        key: GRAFANA_SECRET_KEY

--- a/k8s/external-secrets/jenkins-admin-externalsecret.yaml
+++ b/k8s/external-secrets/jenkins-admin-externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: oci-vault
+    name: infisical-oke-jenkins
   target:
     name: jenkins-admin-credentials
     creationPolicy: Owner
@@ -18,7 +18,7 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: jenkins-admin-username
+        key: JENKINS_ADMIN_USERNAME
     - secretKey: password
       remoteRef:
-        key: jenkins-admin-password
+        key: JENKINS_ADMIN_PASSWORD

--- a/k8s/external-secrets/jenkins-github-externalsecret.yaml
+++ b/k8s/external-secrets/jenkins-github-externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: oci-vault
+    name: infisical-oke-jenkins
   target:
     name: github-token
     creationPolicy: Owner
@@ -24,4 +24,4 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: jenkins-github-token
+        key: JENKINS_GITHUB_TOKEN

--- a/k8s/external-secrets/jenkins-pipelinehealer-bridge-externalsecret.yaml
+++ b/k8s/external-secrets/jenkins-pipelinehealer-bridge-externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: oci-vault
+    name: infisical-oke-jenkins
   target:
     name: pipelinehealer-bridge-secret
     creationPolicy: Owner
@@ -23,7 +23,7 @@ spec:
   data:
     - secretKey: text
       remoteRef:
-        key: jenkins-pipelinehealer-bridge-secret
+        key: JENKINS_PIPELINEHEALER_BRIDGE_SECRET
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -34,7 +34,7 @@ spec:
   refreshInterval: 1m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: oci-vault
+    name: infisical-oke-jenkins
   target:
     name: pipelinehealer-bridge-url
     creationPolicy: Owner
@@ -50,4 +50,4 @@ spec:
   data:
     - secretKey: text
       remoteRef:
-        key: jenkins-pipelinehealer-bridge-url
+        key: JENKINS_PIPELINEHEALER_BRIDGE_URL


### PR DESCRIPTION
## Summary
- add scoped Infisical ClusterSecretStores for monitoring and Jenkins OKE secrets
- switch existing Grafana/Jenkins ExternalSecrets from OCI Vault to Infisical while preserving target Secret names and keys
- update the public OKE Infisical migration doc with the existing ESO consumer cutover

## Verification
- kubectl apply --dry-run=server -f k8s/external-secrets/clustersecretstore-infisical-oke-monitoring.yaml -f k8s/external-secrets/clustersecretstore-infisical-oke-jenkins.yaml -f k8s/external-secrets/grafana-admin-externalsecret.yaml -f k8s/external-secrets/jenkins-admin-externalsecret.yaml -f k8s/external-secrets/jenkins-github-externalsecret.yaml -f k8s/external-secrets/jenkins-pipelinehealer-bridge-externalsecret.yaml
- git diff --check
- added-source scan for private project id, token values, and literal staged secret assignments

## Boundary
Values were staged privately in Infisical with redacted proof only. This PR contains only non-secret store names, folder paths, and remote key names.