### PR TITLE
Manage manual monitoring secrets from Infisical

### DIFF
--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -74,8 +74,10 @@ Public docs and PRs must not include:
 2. **Grafana SMTP credentials**
    - Target shape: keep `monitoring/grafana-smtp-credentials` with keys
      `password`, `user`, `from_address`, and `to_address`.
-   - Cutover method: sync from Infisical, restart Grafana and Alertmanager,
-     prove alert notification config loads without printing values.
+   - Cutover method: sync from Infisical through
+     `ClusterSecretStore/infisical-oke-monitoring`, restart Grafana and
+     Alertmanager, prove alert notification config loads without printing
+     values.
    - Rollback: restore the previous Kubernetes Secret shape.
 
 3. **Jenkins OCI Vault-backed secrets**
@@ -91,8 +93,9 @@ Public docs and PRs must not include:
 4. **Loki/Tempo S3 credentials**
    - Target shape: keep `monitoring/loki-s3-credentials` with the current AWS
      SDK-compatible keys.
-   - Cutover method: sync from Infisical, restart Loki and Tempo, prove write
-     and read paths with status/health checks only.
+   - Cutover method: sync from Infisical through
+     `ClusterSecretStore/infisical-oke-monitoring`, restart Loki and Tempo,
+     prove write and read paths with status/health checks only.
    - Rollback: restore previous Secret source.
 
 5. **Observability remote-write auth and SignalForge agent credentials**
@@ -159,3 +162,17 @@ Secret names and keys:
 The public repo contains only non-secret store names, folder paths, and remote
 key names. Private operator proof owns value staging, service-token creation,
 and rollback notes.
+
+## Manual Monitoring Secret Cutover
+
+The manual monitoring batch moves existing Kubernetes Secrets to Infisical while
+preserving their live names and keys:
+
+- `monitoring/grafana-smtp-credentials`
+- `monitoring/loki-s3-credentials`
+- `monitoring/oci-s3-creds`
+- `monitoring/observability-auth`
+
+These are still mounted or referenced by existing Helm values and ingress
+annotations. The ExternalSecret manifests intentionally keep the same Secret
+names so the application manifests do not need credential reference changes.

--- a/k8s/external-secrets/grafana-smtp-externalsecret.yaml
+++ b/k8s/external-secrets/grafana-smtp-externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-smtp-credentials
+  namespace: monitoring
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke-monitoring
+  target:
+    name: grafana-smtp-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: GRAFANA_SMTP_PASSWORD
+    - secretKey: user
+      remoteRef:
+        key: GRAFANA_SMTP_USER
+    - secretKey: from_address
+      remoteRef:
+        key: GRAFANA_SMTP_FROM_ADDRESS
+    - secretKey: to_address
+      remoteRef:
+        key: GRAFANA_SMTP_TO_ADDRESS

--- a/k8s/external-secrets/monitoring-object-storage-externalsecrets.yaml
+++ b/k8s/external-secrets/monitoring-object-storage-externalsecrets.yaml
@@ -1,0 +1,47 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: loki-s3-credentials
+  namespace: monitoring
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke-monitoring
+  target:
+    name: loki-s3-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: LOKI_S3_AWS_ACCESS_KEY_ID
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: LOKI_S3_AWS_SECRET_ACCESS_KEY
+    - secretKey: access_key
+      remoteRef:
+        key: LOKI_S3_ACCESS_KEY
+    - secretKey: secret_key
+      remoteRef:
+        key: LOKI_S3_SECRET_KEY
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oci-s3-creds
+  namespace: monitoring
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke-monitoring
+  target:
+    name: oci-s3-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: access_key
+      remoteRef:
+        key: OCI_S3_ACCESS_KEY
+    - secretKey: secret_key
+      remoteRef:
+        key: OCI_S3_SECRET_KEY

--- a/k8s/external-secrets/observability-auth-externalsecret.yaml
+++ b/k8s/external-secrets/observability-auth-externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: observability-auth
+  namespace: monitoring
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke-monitoring
+  target:
+    name: observability-auth
+    creationPolicy: Owner
+  data:
+    - secretKey: auth
+      remoteRef:
+        key: OBSERVABILITY_BASIC_AUTH


### PR DESCRIPTION
## Summary
- add ExternalSecrets for the manual monitoring Secrets already consumed by Grafana, Alertmanager, Loki, Tempo, and the observability ingress
- keep the existing Kubernetes Secret names and keys stable
- update the OKE Infisical migration doc with the manual monitoring batch

## Verification
- `kubectl apply --dry-run=server -f k8s/external-secrets/grafana-smtp-externalsecret.yaml -f k8s/external-secrets/monitoring-object-storage-externalsecrets.yaml -f k8s/external-secrets/observability-auth-externalsecret.yaml`
- `git diff --check`
- added-source scan for private project id, literal secret values, token material, and staged secret assignments

## Boundary
The current live values were staged privately in Infisical with redacted proof only. This PR contains only non-secret store names and remote key names.
