### PR TITLE
Manage SignalForge agent token from Infisical

### DIFF
--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -176,3 +176,18 @@ preserving their live names and keys:
 These are still mounted or referenced by existing Helm values and ingress
 annotations. The ExternalSecret manifests intentionally keep the same Secret
 names so the application manifests do not need credential reference changes.
+
+## SignalForge Agent Token Cutover
+
+`signalforge/signalforge-agent-token` is managed as a transitional
+ExternalSecret from `ClusterSecretStore/infisical-oke-signalforge`.
+
+The target uses `creationPolicy: Merge` because the `signalforge-agent` Helm
+release still owns the Secret object contract. This keeps the token key in
+Infisical without forcing a Helm chart ownership change in the observability
+repo. A later SignalForge-agent chart/source change should switch the release
+to `agent.token.existingSecret` so Helm stops rendering token data entirely.
+
+`signalforge/signalforge-agent-regcred` is not referenced by the live
+`signalforge-agent` Deployment imagePullSecrets. It is not treated as a live
+consumer until a source manifest uses it.

--- a/k8s/external-secrets/clustersecretstore-infisical-oke-signalforge.yaml
+++ b/k8s/external-secrets/clustersecretstore-infisical-oke-signalforge.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: infisical-oke-signalforge
+spec:
+  provider:
+    infisical:
+      hostAPI: https://app.infisical.com/api
+      auth:
+        tokenAuthCredentials:
+          accessToken:
+            name: infisical-oke-signalforge-auth
+            namespace: external-secrets
+            key: accessToken
+      secretsScope:
+        projectSlug: canepro-secrets
+        environmentSlug: prod
+        secretsPath: /platform/oke/signalforge
+        recursive: false
+        expandSecretReferences: false

--- a/k8s/external-secrets/signalforge-agent-token-externalsecret.yaml
+++ b/k8s/external-secrets/signalforge-agent-token-externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: signalforge-agent-token
+  namespace: signalforge
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical-oke-signalforge
+  target:
+    name: signalforge-agent-token
+    # The Helm release still owns the Secret object contract. Merge lets ESO
+    # manage the token key without changing the chart-managed labels yet.
+    creationPolicy: Merge
+  data:
+    - secretKey: token
+      remoteRef:
+        key: SIGNALFORGE_AGENT_TOKEN


### PR DESCRIPTION
## Summary
- add a scoped Infisical ClusterSecretStore for the SignalForge OKE agent token
- add a transitional ExternalSecret for `signalforge/signalforge-agent-token` using `creationPolicy: Merge`
- document why `signalforge-agent-regcred` is not migrated as a live consumer yet

## Verification
- `kubectl apply --dry-run=server -f k8s/external-secrets/clustersecretstore-infisical-oke-signalforge.yaml -f k8s/external-secrets/signalforge-agent-token-externalsecret.yaml`
- `git diff --check`
- added-source scan for private project id, token values, access-token literals, and staged secret assignments

## Boundary
The current token value was staged privately in Infisical with redacted proof only. The live deployment is scaled to zero, so post-merge proof is ESO readiness and target Secret shape; runtime heartbeat remains intentionally paused unless separately approved.
