### PR TITLE
Update OKE secret-source docs for Infisical

### DIFF
--- a/GITOPS-HANDOVER.md
+++ b/GITOPS-HANDOVER.md
@@ -82,10 +82,10 @@ Detailed cutover and troubleshooting runbook:
   ```
 
 ### 🔐 Secrets Management (Hub)
-- Grafana admin credentials and `secret_key` are stored in **OCI Vault** and synced into Kubernetes via **External Secrets Operator (ESO)**.
-- Source manifests: `k8s/external-secrets/` (ClusterSecretStore + ExternalSecret).
+- Grafana admin credentials and `secret_key` are stored in **Infisical** and synced into Kubernetes via **External Secrets Operator (ESO)**.
+- Source manifests: `k8s/external-secrets/` (Infisical ClusterSecretStore + ExternalSecret).
 - Grafana secret name: `grafana` (keys: `admin-user`, `admin-password`, `secret_key`).
-- After rotating secrets in OCI Vault, ESO refreshes the Kubernetes secret automatically (default refresh: 1h).
+- After rotating secrets in Infisical, ESO refreshes the Kubernetes secret automatically (default refresh: 1h).
 
 ### 🛡️ Automated Guardrails
 - **OCI Storage Audit**: Use `./scripts/check-oci-storage.sh` to verify we are under the 200GB Always Free limit (currently at 194GB).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This stack is managed declaratively via ArgoCD. All changes flow through Git:
 
 - ArgoCD watches the `main` branch - every push triggers reconciliation
 - For PVC-backed components (Grafana, Prometheus), take snapshots before upgrades
-- Grafana admin credentials and `secret_key` are sourced from OCI Vault via External Secrets Operator (`k8s/external-secrets/`)
+- Grafana admin credentials and `secret_key` are sourced from Infisical via External Secrets Operator (`k8s/external-secrets/`)
 - Run `./scripts/validate-deployment.sh` after changes to verify health
 
 ## Documentation

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,7 +27,7 @@ This guide provides step-by-step instructions for connecting your applications t
 3. **Password**: use the approved operator credential path. Do not decode or
    paste the Kubernetes Secret value into shared terminals, tickets, reports, or
    PR comments.
-   (Source: External Secrets Operator syncs from OCI Vault into `grafana`)
+   (Source: External Secrets Operator syncs from Infisical into `grafana`)
 
 ### Change Admin Password
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,7 +9,7 @@
 **Login:** use the approved operator credential path. Do not print the Grafana
 admin password into chat, tickets, shared terminals, reports, or PR comments.
 
-**Note**: Admin credentials and Grafana `secret_key` are sourced from OCI Vault
+**Note**: Admin credentials and Grafana `secret_key` are sourced from Infisical
 via External Secrets Operator into the `grafana` secret.
 
 **Note**: If HTTPS certificate errors occur, wait 2-3 minutes for certificate propagation or use HTTP fallback: http://grafana.canepro.me

--- a/helm/grafana-values.yaml
+++ b/helm/grafana-values.yaml
@@ -91,7 +91,7 @@ envValueFrom:
       name: grafana-smtp-credentials
       key: from_address
 
-# Admin credentials are managed by ExternalSecrets (OCI Vault) into Secret `grafana`.
+# Admin credentials are managed by ExternalSecrets (Infisical) into Secret `grafana`.
 # Tell the chart to use that existing secret and not generate/overwrite one.
 admin:
   existingSecret: grafana

--- a/helm/jenkins-values.yaml
+++ b/helm/jenkins-values.yaml
@@ -19,7 +19,7 @@ controller:
   numExecutors: 0
   executorMode: NORMAL
 
-  # Admin: sourced from ExternalSecret/OCI Vault so login is reproducible from GitOps.
+  # Admin: sourced from ExternalSecret/Infisical so login is reproducible from GitOps.
   admin:
     createSecret: false
     existingSecret: "jenkins-admin-credentials"

--- a/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
+++ b/hub-docs/OKE-INFISICAL-SECRETS-MIGRATION.md
@@ -6,22 +6,25 @@ or operator-specific Infisical metadata here.
 
 ## Current Secret Delivery
 
-The OKE hub currently uses a mixed model:
+After the May 28 cutovers, approved live OKE/GitOps consumers sync from
+Infisical through External Secrets Operator while keeping their Kubernetes
+Secret names and key shapes stable:
 
 | Class | Current delivery | GitOps consumer | Migration posture |
 | --- | --- | --- | --- |
-| Grafana admin and `secret_key` | External Secrets Operator from OCI Vault | `monitoring/grafana` and `helm/grafana-values.yaml` | Keep live path until an Infisical-backed ESO store is proven |
-| Jenkins admin | External Secrets Operator from OCI Vault | `jenkins/jenkins-admin-credentials` and `helm/jenkins-values.yaml` | Candidate for staged Infisical mirror, then source cutover |
-| Jenkins GitHub token | External Secrets Operator from OCI Vault | `jenkins/github-token` and Jenkins credentials provider | Candidate after token owner, scope, and rotation path are confirmed |
-| PipelineHealer Jenkins bridge values | External Secrets Operator from OCI Vault | `jenkins/pipelinehealer-bridge-*` | Candidate after PipelineHealer consumer smoke is defined |
-| Argo CD OIDC client secret | Manual Kubernetes Secret referenced by Argo CD | `argocd/argocd-oidc-client-secret` and `terraform/argocd-auth.tf` | Good first OKE cutover candidate; low shape complexity, clear rollback |
-| Grafana SMTP credentials | Manual Kubernetes Secret | `monitoring/grafana-smtp-credentials`, Grafana, Alertmanager | Candidate after mail owner and app-password rotation path are confirmed |
-| Loki/Tempo S3 credentials | Manual Kubernetes Secret | `monitoring/loki-s3-credentials`, Loki, Tempo | Candidate after object-storage access key scope and rollback are confirmed |
-| Observability basic auth | Manual Kubernetes Secret | `monitoring/observability-auth`, remote-write clients | Higher blast radius; migrate after spoke cutover plan exists |
+| Grafana admin and `secret_key` | External Secrets Operator from Infisical | `monitoring/grafana` and `helm/grafana-values.yaml` | Live, proved by store readiness, ExternalSecret sync, and Grafana health |
+| Jenkins admin | External Secrets Operator from Infisical | `jenkins/jenkins-admin-credentials` and `helm/jenkins-values.yaml` | Live, with the Jenkins chart consuming the existing Secret |
+| Jenkins GitHub token | External Secrets Operator from Infisical | `jenkins/github-token` and Jenkins credentials provider | Live, with Jenkins credential ID preserved |
+| PipelineHealer Jenkins bridge values | External Secrets Operator from Infisical | `jenkins/pipelinehealer-bridge-*` | Live, with Jenkins credential IDs preserved |
+| Argo CD OIDC client secret | External Secrets Operator from Infisical | `argocd/argocd-oidc-client-secret` and `terraform/argocd-auth.tf` | Live, with the Argo CD Secret shape preserved |
+| Grafana SMTP credentials | External Secrets Operator from Infisical | `monitoring/grafana-smtp-credentials`, Grafana, Alertmanager | Live, with alerting key shape preserved |
+| Loki/Tempo S3 credentials | External Secrets Operator from Infisical | `monitoring/loki-s3-credentials`, Loki, Tempo | Live, with object-storage key shape preserved |
+| Observability basic auth | External Secrets Operator from Infisical | `monitoring/observability-auth`, remote-write clients | Live, with ingress auth Secret name preserved |
 | TLS and cert-manager secrets | Controller-managed Kubernetes Secrets | cert-manager, ingress controllers | Leave controller-owned; do not migrate values to Infisical |
 | Helm release secrets | Helm internal state | Helm/Argo CD | Leave unmanaged by Infisical |
 | Argo repo and cluster credentials | Argo-managed Kubernetes Secrets | Argo CD | Handle separately; may include stale or cross-cluster credentials |
-| SignalForge agent token and pull secret | Helm/manual Kubernetes Secrets | `signalforge-agent` | Coordinate through SignalForge/Selene runbook before value movement |
+| SignalForge agent token | External Secrets Operator from Infisical with `creationPolicy: Merge` | `signalforge-agent` | Live transitional cutover; hold chart ownership cleanup for `existingSecret` follow-up |
+| SignalForge pull secret | Not referenced by the live Deployment imagePullSecrets | `signalforge-agent-regcred` | Guarded holdout until a source manifest uses it or deletion is explicitly approved |
 
 ## Target Model
 
@@ -46,7 +49,7 @@ Public docs and PRs may include:
 - Kubernetes namespace and Secret name
 - expected key names
 - owning controller or consumer
-- current source class such as OCI Vault, manual Kubernetes Secret, Helm, or cert-manager
+- current source class such as Infisical, Helm, cert-manager, or a retained rollback source
 - target store class such as Infisical via ESO
 - rollout and rollback steps
 - redacted proof shape
@@ -80,7 +83,7 @@ Public docs and PRs must not include:
      values.
    - Rollback: restore the previous Kubernetes Secret shape.
 
-3. **Jenkins OCI Vault-backed secrets**
+3. **Jenkins secrets**
    - Target shape: keep existing Kubernetes Secret names and Jenkins credential
      IDs.
    - Cutover method: mirror one Jenkins credential family at a time, then switch
@@ -88,7 +91,9 @@ Public docs and PRs must not include:
      first source-backed cutover uses the scoped
      `ClusterSecretStore/infisical-oke-jenkins` and preserves existing target
      Secrets.
-   - Rollback: switch the ExternalSecret back to OCI Vault.
+   - Rollback: restore the previous Kubernetes Secret shape or switch the
+     ExternalSecret back to the retained rollback source if that rollback source
+     still exists.
 
 4. **Loki/Tempo S3 credentials**
    - Target shape: keep `monitoring/loki-s3-credentials` with the current AWS
@@ -149,9 +154,9 @@ target Secret key shape, Argo rollout status, and SSO/admin success.
 
 ## Existing ESO Consumer Cutover
 
-After the Argo OIDC pilot, the next reviewed GitOps cutover moves existing OCI
-Vault-backed ESO consumers to Infisical while preserving their live Kubernetes
-Secret names and keys:
+After the Argo OIDC pilot, the next reviewed GitOps cutover moved existing ESO
+consumers to Infisical while preserving their live Kubernetes Secret names and
+keys:
 
 - `monitoring/grafana`
 - `jenkins/jenkins-admin-credentials`

--- a/hub-docs/OPERATIONS-HUB.md
+++ b/hub-docs/OPERATIONS-HUB.md
@@ -305,10 +305,10 @@ In this repo those are enabled via `serverFiles.prometheus.yml.scrape_configs` i
 If the PVC panel shows `No data`, check whether these metrics exist in Prometheus Explore first.
 Scrapes use the service account CA for TLS verification (no `insecure_skip_verify`).
 
-## 🔐 Secrets Management (ESO + OCI Vault)
-- External Secrets Operator (ESO) runs in `external-secrets` and syncs from OCI Vault.
-- Grafana admin credentials and `secret_key` live in Vault and are synced to `monitoring/grafana`.
-- Source manifests: `k8s/external-secrets/` (ClusterSecretStore + ExternalSecret).
+## 🔐 Secrets Management (ESO + Infisical)
+- External Secrets Operator (ESO) runs in `external-secrets` and syncs from Infisical.
+- Grafana admin credentials and `secret_key` live in Infisical and are synced to `monitoring/grafana`.
+- Source manifests: `k8s/external-secrets/` (Infisical ClusterSecretStore + ExternalSecret).
 
 ## 🔑 Grafana Admin Password Reset
 If you lose access to the Grafana UI, rotate the source secret

--- a/hub-docs/README.md
+++ b/hub-docs/README.md
@@ -35,8 +35,8 @@ The stack uses the App-of-Apps pattern. The bootstrap manifest (`argocd/bootstra
 
 ## Secrets Management
 
-- **External Secrets Operator (ESO)** runs in `external-secrets` and syncs secrets from **OCI Vault**.
-- Grafana admin credentials and `secret_key` are stored in Vault and materialized as `monitoring/grafana`.
+- **External Secrets Operator (ESO)** runs in `external-secrets` and syncs hub secrets from **Infisical**.
+- Grafana admin credentials and `secret_key` are stored in Infisical and materialized as `monitoring/grafana`.
 - ESO config manifests live in `k8s/external-secrets/`.
 - ESO CRDs are installed out-of-band via server-side apply; Helm values set `installCRDs: false`.
 
@@ -45,6 +45,7 @@ The stack uses the App-of-Apps pattern. The bootstrap manifest (`argocd/bootstra
 - [ARCHITECTURE.md](ARCHITECTURE.md) - System design and storage architecture
 - [CLUSTER-INFO.md](CLUSTER-INFO.md) - OKE cluster details and access commands
 - [OPERATIONS-HUB.md](OPERATIONS-HUB.md) - Retention policies and maintenance
+- [GRAFANA-MCP-SRE.md](GRAFANA-MCP-SRE.md) - Grafana MCP setup for local SRE callups
 - [TRACING-ROLLOUT-CHECKLIST.md](TRACING-ROLLOUT-CHECKLIST.md) - Phased tracing rollout gates for useful service graphs and drilldown
 - [TRACING-SERVICE-ONBOARDING-TEMPLATE.md](TRACING-SERVICE-ONBOARDING-TEMPLATE.md) - Copy/paste checklist for onboarding one service to tracing
 - [TRACING-ONBOARDING-argocd-server.md](TRACING-ONBOARDING-argocd-server.md) - Pre-filled onboarding example for `argocd-server`


### PR DESCRIPTION
## Summary
- update current OKE secret-source docs and Helm comments from OCI Vault to Infisical
- refresh the OKE Infisical migration inventory to reflect the May 28 cutovers
- keep rollback-source deletion and SignalForge token ownership cleanup out of this PR

## Proof
- `git diff --cached --check` passed before commit
- `rg -n "oci-vault|ClusterSecretStore/oci-vault|name: oci-vault" k8s argocd helm docs hub-docs README.md GITOPS-HANDOVER.md` now only returns `k8s/external-secrets/clustersecretstore-oci.yaml:4`
- remaining `OCI Vault` text is historical planning or explicit value-handling boundary language, not active source-of-truth docs

## Guarded holdouts
- `k8s/external-secrets/clustersecretstore-oci.yaml` remains in place because Argo prunes `k8s/external-secrets`, so deleting it would remove the rollback store from the cluster
- `signalforge-agent-token` remains `creationPolicy: Merge` until the release is moved to chart-level `existingSecret` ownership

## Rollback
- revert this commit to restore the previous wording
- do not delete the OCI Vault ClusterSecretStore until live ExternalSecret consumers are checked and rollback-source removal is explicitly approved

Refs #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect secrets infrastructure migration from OCI Vault to Infisical.
  * Grafana and Jenkins admin credentials are now sourced from Infisical.
  * External Secrets Operator continues to sync credentials to your environment using the new backend.
  * All operational guides and configuration documentation updated to reflect the new secrets source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->