### PR TITLE
Fix Rocket.Chat scheduled Jenkins jobs on main

### DIFF
--- a/helm/jenkins-values.yaml
+++ b/helm/jenkins-values.yaml
@@ -180,9 +180,9 @@ controller:
         jobs:
           - script: |
               pipelineJob('version-check-rocketchat-k8s') {
-                description('Automated version checking pipeline for rocketchat-k8s. Runs weekdays at 5 PM and stays aligned with the repo Jenkinsfile.')
+                description('Automated version checking pipeline for rocketchat-k8s. Runs on weekdays during 14:30-14:59 Europe/London and stays aligned with the repo Jenkinsfile.')
                 triggers {
-                  cron('H 17 * * 1-5')
+                  cron('H(30-59) 14 * * 1-5')
                 }
                 definition {
                   cpsScm {
@@ -192,7 +192,7 @@ controller:
                           url('https://github.com/Canepro/rocketchat-k8s')
                           credentials('github-token')
                         }
-                        branch('*/master')
+                        branch('*/main')
                         extensions {
                           cleanBeforeCheckout()
                         }
@@ -204,9 +204,9 @@ controller:
                 }
               }
               pipelineJob('security-validation-rocketchat-k8s') {
-                description('Automated security validation pipeline for rocketchat-k8s. Runs weekdays at 6 PM and stays aligned with the repo Jenkinsfile.')
+                description('Automated security validation pipeline for rocketchat-k8s. Runs on weekdays during 15:00-15:29 Europe/London and stays aligned with the repo Jenkinsfile.')
                 triggers {
-                  cron('H 18 * * 1-5')
+                  cron('H(0-29) 15 * * 1-5')
                 }
                 definition {
                   cpsScm {
@@ -216,7 +216,7 @@ controller:
                           url('https://github.com/Canepro/rocketchat-k8s')
                           credentials('github-token')
                         }
-                        branch('*/master')
+                        branch('*/main')
                         extensions {
                           cleanBeforeCheckout()
                         }


### PR DESCRIPTION
## Summary
- align the OKE Jenkins controller JCasC with the current `rocketchat-k8s` job definitions
- switch the scheduled Rocket.Chat jobs from `master` to `main`
- update the weekday cron windows and descriptions to match the repo source of truth

## Why
The live Jenkins scheduled jobs are reconciled from this repo, not directly from `rocketchat-k8s`. The controller-side Job DSL here was stale and still targeted `branch('*/master')`, which no longer matches the repository default branch.

## Validation
- `python3` YAML parse of `helm/jenkins-values.yaml`
- compared the managed job block with `/Users/canepro/src/rocketchat-k8s/jenkins-values.yaml`
- verified the broken live job previously failed in Jenkins with `scm` null before pipeline execution
