### PR TITLE
Pin Jenkins plugin dependency minimums

### DIFF
--- a/helm/jenkins-values.yaml
+++ b/helm/jenkins-values.yaml
@@ -89,6 +89,9 @@ controller:
   # Plugins: use latest versions for all plugins (security + features)
   # GitOps policy: manage plugin changes here and via ArgoCD sync; avoid UI plugin install/uninstall to prevent drift.
   installPlugins:
+    # Keep critical transitive deps explicitly above the minimums required by current plugins.
+    - prism-api:1.30.0-717.vb_f8360844b_53
+    - bouncycastle-api:2.30.1.83-289.v8426fcd19371
     - configuration-as-code:latest
     - credentials-binding:latest
     - git:latest


### PR DESCRIPTION
## Summary
- pin `prism-api` above the minimum required by the current Configuration as Code plugin
- pin `bouncycastle-api` above the minimum required by the current Credentials plugin
- keep the rest of the Jenkins plugin set unchanged

## Why
After the scheduled Rocket.Chat job source-of-truth fix merged, a controlled Jenkins controller restart exposed a broader plugin dependency drift on OKE. Jenkins failed to load `configuration-as-code` because `prism-api` was too old, and failed to load `credentials` because `bouncycastle-api` was too old. That cascaded into git, GitHub, pipeline, and scheduled-job failures.

## Validation
- `python3` YAML parse of `helm/jenkins-values.yaml`
- verified Jenkins startup log dependency errors on OKE before this change
