### PR TITLE
Pin Jenkins plugin set

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -48,6 +48,8 @@ When you want to run **terraform plan**, the pipeline needs OCI **identifiers** 
 
 If both parameters and credentials are empty, the pipeline runs only **Terraform Format** and **Terraform Validate** (with `terraform init -backend=false`), so PR and branch builds pass without OCI credentials.
 
+The Terraform validation agent installs OCI CLI in a temporary Python virtual environment when full OCI credentials are available. The OKE ARM agent may resolve Python dependencies without prebuilt wheels, so the Jenkinsfile installs Alpine `build-base` and `python3-dev` before `pip install oci-cli`; otherwise packages such as `crc32c` can fail with `cc: No such file or directory`.
+
 **Credential IDs** (create as **Secret text** under the GrafanaLocal folder). Use the **Description** field in Jenkins so you know what each one is later:
 
 | Credential ID           | Description | Secret text value |

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -111,7 +111,8 @@ EOF
             # The terraform container may not ship with the OCI CLI, so install it if missing.
             if ! command -v oci >/dev/null 2>&1; then
               echo "Installing OCI CLI (required for Helm provider auth)..."
-              apk add --no-cache bash curl ca-certificates python3 py3-pip >/dev/null 2>&1 || true
+              # oci-cli can pull Python deps without aarch64/cp314 wheels; keep a compiler available for source builds.
+              apk add --no-cache bash curl ca-certificates python3 py3-pip python3-dev build-base >/dev/null 2>&1 || true
               update-ca-certificates >/dev/null 2>&1 || true
               python3 -m venv /tmp/oci-cli-venv >/dev/null 2>&1 || true
               if [ -f /tmp/oci-cli-venv/bin/activate ]; then

--- a/docs/JENKINS-503-TROUBLESHOOTING.md
+++ b/docs/JENKINS-503-TROUBLESHOOTING.md
@@ -64,6 +64,7 @@ kubectl get pods -n jenkins -l app.kubernetes.io/component=jenkins-controller -w
 - **Plugin error:** If logs show a specific plugin failing:
   1. Temporarily remove that plugin from `controller.installPlugins` in `helm/jenkins-values.yaml`, or
   2. Disable it at runtime: exec into the pod and remove its directory under `$JENKINS_HOME/plugins`, then restart (only if you are comfortable with that).
+  3. If the error says `Update required` for a dependency plugin, do not remove the dependent root plugin first. Compare the stale dependency under `$JENKINS_HOME/plugins` with `/usr/share/jenkins/ref/plugins/`, then refresh or pin that dependency.
 
 - **`No hudson.slaves.Cloud implementation found for kubernetes`:** JCasC is applying a kubernetes cloud from the chart default, but the plugin isn’t ready at init. Fix: set `jenkins.clouds: []` in JCasC so no dynamic cloud is configured (you only use the static aks-agent). Add a configScript in `controller.JCasC.configScripts` (e.g. `no-kubernetes-cloud`) with `jenkins: clouds: []`, then redeploy.
 
@@ -93,13 +94,16 @@ For deprecated plugin banners:
 Use this flow for plugin updates without UI drift:
 
 1. Update `controller.installPlugins` in `helm/jenkins-values.yaml` (add/remove/pin as needed), commit, and push.
+   - Prefer explicit versions over `:latest` for the OKE controller. This Jenkins instance keeps `JENKINS_HOME` on a persistent volume, and floating plugin resolution can leave older plugin artifacts on disk that only break on a later restart.
+   - Set `controller.overwritePlugins: true` when the desired plugin set is known and the goal is to force the persistent plugin volume back to the Git-declared versions.
 2. Wait for ArgoCD to reconcile:
    ```bash
    kubectl -n argocd get application jenkins
    kubectl -n jenkins get configmap jenkins -o jsonpath='{.data.plugins\.txt}'
    ```
-3. If Jenkins still shows old plugin versions, refresh only the affected plugin files in `$JENKINS_HOME/plugins`:
+3. If Jenkins still shows old plugin versions after the GitOps overwrite path, refresh only the affected plugin files in `$JENKINS_HOME/plugins` during a controlled maintenance window:
    - Move `<plugin>.jpi` and related marker files (`.pinned`, `.version_from_image`, optional extracted dir) to a timestamped backup under `/var/jenkins_home/plugin-backups/<ts>/`.
+   - Copy the matching `.jpi` from `/usr/share/jenkins/ref/plugins/` back into `$JENKINS_HOME/plugins/`.
    - Restart Jenkins (`kubectl -n jenkins rollout restart sts/jenkins`).
 4. Verify post-restart:
    ```bash
@@ -111,6 +115,7 @@ Use this flow for plugin updates without UI drift:
 Notes:
 - This repo intentionally avoids plugin install/uninstall from UI as source of truth.
 - `JENKINS_HOME/plugins` can preserve older plugin artifacts on PVC; cleanup is sometimes required after code-managed plugin changes.
+- If startup logs say `Update required` for a dependency plugin such as `prism-api` or `bouncycastle-api`, compare the version loaded from `$JENKINS_HOME/plugins` with the version in `/usr/share/jenkins/ref/plugins/` before changing anything else. That exact mismatch is a strong stale-PVC signal.
 
 ---
 

--- a/helm/jenkins-values.yaml
+++ b/helm/jenkins-values.yaml
@@ -86,27 +86,52 @@ controller:
     - JNLP-connect
     - JNLP2-connect
 
-  # Plugins: use latest versions for all plugins (security + features)
+  # Plugins: keep the controller plugin set explicit and reproducible.
+  # This controller uses a long-lived PVC for JENKINS_HOME, so floating plugin resolution
+  # can leave older plugin artifacts on disk and then break later restarts.
   # GitOps policy: manage plugin changes here and via ArgoCD sync; avoid UI plugin install/uninstall to prevent drift.
   installPlugins:
-    # Keep critical transitive deps explicitly above the minimums required by current plugins.
     - prism-api:1.30.0-717.vb_f8360844b_53
     - bouncycastle-api:2.30.1.83-289.v8426fcd19371
-    - configuration-as-code:latest
-    - credentials-binding:latest
-    - git:latest
-    - github:latest
-    - workflow-aggregator:latest
-    - kubernetes:latest
-    - kubernetes-credentials-provider:latest
-    - pipeline-model-definition:latest
-    - pipeline-graph-view:latest
-    - pipeline-stage-view:latest
-    - github-branch-source:latest
-    - job-dsl:latest
-    - sshd:latest
-    - ws-cleanup:latest
-  installLatestPlugins: true
+    - configuration-as-code:2088.ve3b_42c663c80
+    - credentials-binding:725.ve52b_2328a_fde
+    - git:5.10.1
+    - github:1.47.0
+    - workflow-aggregator:608.v67378e9d3db_1
+    - kubernetes:4423.vb_59f230b_ce53
+    - kubernetes-credentials-provider:1.303.vdfcf47fb_b_fef
+    - pipeline-model-definition:2.2291.v2934911987b_6
+    - pipeline-graph-view:940.v790e7a_c51722
+    - pipeline-stage-view:2.41
+    - github-branch-source:1967.1969.v205fd594c821
+    - job-dsl:3654.vdf58f53e2d15
+    - sshd:3.384.vc89b_5e138cf9
+    - ws-cleanup:0.49
+    # Transitive pins that have drifted on the persistent JENKINS_HOME plugin volume.
+    - asm-api:9.10.1-216.va_9256d3b_844b_
+    - durable-task:671.v340ff7959010
+    - git-client:6.6.0
+    - gson-api:2.14.0-201.v8eefe5515533
+    - jackson2-api:2.21.2-436.v29efdb_7418ff
+    - jakarta-xml-bind-api:4.0.9-19.v2b_a_5b_44d9a_1c
+    - joda-time-api:2.14.2-193.v422b_efce56e0
+    - mailer:534.v1b_36f5864073
+    - mina-sshd-api-common:2.17.1-187.v0341274c2905
+    - mina-sshd-api-core:2.17.1-187.v0341274c2905
+    - okhttp-api:5.3.2-200.vedb_720a_cf1f8
+    - pipeline-groovy-lib:798.v5cc688825312
+    - pipeline-input-step:551.vdff487c5998c
+    - pipeline-milestone-step:152.v6e22b_8cfc66c
+    - pipeline-model-api:2.2291.v2934911987b_6
+    - pipeline-stage-step:345.va_96187909426
+    - pipeline-stage-tags-metadata:2.2291.v2934911987b_6
+    - ssh-credentials:372.va_250881b_08cd
+    - workflow-api:1413.v2ff1a_5e720fa_
+    - workflow-durable-task-step:1479.v56e587f413a_7
+    - workflow-job:1571.1580.v18e46842c125
+    - workflow-step-api:724.v538c2362b_dfb_
+  installLatestPlugins: false
+  overwritePlugins: true
   overwritePluginsFromImage: true
 
   # JCasC: welcome message + static node for AKS agent. defaultConfig: false so chart does not inject kubernetes cloud (avoids ConfigurationAsCodeBootFailure).


### PR DESCRIPTION
## Summary
- pin the OKE Jenkins controller plugin set instead of relying on floating `:latest` resolution
- enable plugin overwrite so the persistent `JENKINS_HOME` plugin volume reconciles back to Git-declared versions
- document the stale-PVC plugin recovery path for `Update required` dependency failures

## Verification
- `helm lint /tmp/jenkins-chart-5.8.0/jenkins -f helm/jenkins-values.yaml`
- `helm template jenkins /tmp/jenkins-chart-5.8.0/jenkins -n jenkins -f helm/jenkins-values.yaml`
- rendered chart includes `jenkins-plugin-cli --latest false`
- live Jenkins controller login returned HTTP 200
- Argo app `jenkins` reported `Synced`, `Healthy`, `Succeeded`
- recent Jenkins controller logs had no `Failed Loading plugin`, `Update required`, `SCM.getKey`, or `No such DSL method` signatures
