### PR TITLE
Pin Jenkins JUnit transitive plugins

### DIFF
--- a/docs/JENKINS-503-TROUBLESHOOTING.md
+++ b/docs/JENKINS-503-TROUBLESHOOTING.md
@@ -115,7 +115,7 @@ Use this flow for plugin updates without UI drift:
 Notes:
 - This repo intentionally avoids plugin install/uninstall from UI as source of truth.
 - `JENKINS_HOME/plugins` can preserve older plugin artifacts on PVC; cleanup is sometimes required after code-managed plugin changes.
-- If startup logs say `Update required` for a dependency plugin such as `prism-api` or `bouncycastle-api`, compare the version loaded from `$JENKINS_HOME/plugins` with the version in `/usr/share/jenkins/ref/plugins/` before changing anything else. That exact mismatch is a strong stale-PVC signal.
+- If startup logs say `Update required` for a dependency plugin such as `prism-api`, `bouncycastle-api`, `checks-api`, or `echarts-api`, compare the version loaded from `$JENKINS_HOME/plugins` with the version in `/usr/share/jenkins/ref/plugins/` before changing anything else. That exact mismatch is a strong stale-PVC signal. If the image reference plugin is also below the requirement, add an explicit `installPlugins` pin so the chart downloads the needed version during init.
 
 ---
 

--- a/helm/jenkins-values.yaml
+++ b/helm/jenkins-values.yaml
@@ -110,6 +110,8 @@ controller:
     # Transitive pins that have drifted on the persistent JENKINS_HOME plugin volume.
     - asm-api:9.10.1-216.va_9256d3b_844b_
     - durable-task:671.v340ff7959010
+    - checks-api:373.vfe7645102093
+    - echarts-api:6.0.0-1146.v5c8f3b_8f0573
     - git-client:6.6.0
     - gson-api:2.14.0-201.v8eefe5515533
     - jackson2-api:2.21.2-436.v29efdb_7418ff


### PR DESCRIPTION
## Summary
- pin `checks-api` and `echarts-api` at the versions required by the current `junit` plugin
- document this `Update required` signature as an explicit plugin pinning case

## Live evidence
After PR #94 reconciled, Jenkins rolled and started with failed plugins:
- `junit` required `checks-api >= 373.vfe7645102093`
- `junit` required `echarts-api >= 6.0.0-1146.v5c8f3b_8f0573`
- `matrix-project` and `ws-cleanup` then failed because `junit` failed

## Verification
- `helm lint /tmp/jenkins-chart-5.8.0/jenkins -f helm/jenkins-values.yaml`
- `helm template jenkins /tmp/jenkins-chart-5.8.0/jenkins -n jenkins -f helm/jenkins-values.yaml`
- rendered plugin file includes `checks-api:373.vfe7645102093`
- rendered plugin file includes `echarts-api:6.0.0-1146.v5c8f3b_8f0573`
