### PR TITLE
Ignore transient Jenkins agents in OKE pod health

### DIFF
--- a/scripts/weekly_oke_observability_check.py
+++ b/scripts/weekly_oke_observability_check.py
@@ -247,8 +247,10 @@ def collect_pods() -> dict[str, Any]:
         namespace = metadata.get("namespace")
         if namespace not in WATCH_NAMESPACES:
             continue
-        watched_count += 1
         name = metadata.get("name")
+        if namespace == "jenkins" and name != "jenkins-0":
+            continue
+        watched_count += 1
         status = item.get("status", {})
         phase = status.get("phase", "Unknown")
         container_statuses = status.get("containerStatuses", []) or []


### PR DESCRIPTION
## Summary
- exclude ephemeral Jenkins agent pods from the stable OKE watched-pod health gate
- keep `jenkins-0` covered by the stable pod check and the dedicated Jenkins controller check

## Verification
- `python3 -m py_compile scripts/weekly_oke_observability_check.py`
- `python3 scripts/weekly_oke_observability_check.py --output-dir /tmp/grafanalocal-weekly-oke-final-smoke-2`
- smoke result no longer fails on an active transient `terraform-oci-*` Jenkins agent pod
