### PR TITLE
Fix duplicate Argo CD ingress TLS entry

### DIFF
--- a/VERSION-TRACKING.md
+++ b/VERSION-TRACKING.md
@@ -46,6 +46,7 @@ Grafana dashboards are provisioned via Helm values in `helm/grafana-values.yaml`
 - Loki 6.55.0 → 7.0.0 (major chart update; app remains 3.6.7)
 - Prometheus 28.13.0 → 29.12.0 (major chart update; app v3.12.0)
 - NGINX Ingress 4.15.0 → 4.15.1 (patch)
+- Metrics Server 3.13.0 → 3.13.1 (patch; app v0.8.1)
 
 **Previously updated (2026-02-02)**:
 - Prometheus 28.7.0 → 28.8.0 (patch)
@@ -136,7 +137,7 @@ Grafana dashboards are provisioned via Helm values in `helm/grafana-values.yaml`
 | Component | Current Version | Latest Version | Upgrade Status | Location | Update Source |
 |-----------|----------------|----------------|----------------|----------|---------------|
 | **NGINX Ingress Controller** | `4.15.1` | `4.15.1` | 🔄 **Just updated** (2026-06-17) | `argocd/applications/nginx-ingress.yaml` | [Ingress-NGINX Releases](https://github.com/kubernetes/ingress-nginx/releases) |
-| **Metrics Server** | `3.13.0` | `3.13.0` | 🔄 **Just updated** (2026-01-19) | `argocd/applications/metrics-server.yaml` | [Metrics Server Releases](https://github.com/kubernetes-sigs/metrics-server/releases) |
+| **Metrics Server** | `3.13.1` | `3.13.1` | 🔄 **Just updated** (2026-06-17) | `argocd/applications/metrics-server.yaml` | [Metrics Server Releases](https://github.com/kubernetes-sigs/metrics-server/releases) |
 
 ---
 

--- a/terraform/argocd.tf
+++ b/terraform/argocd.tf
@@ -28,12 +28,6 @@ resource "helm_release" "argocd" {
             "nginx.ingress.kubernetes.io/ssl-redirect"     = "true"
             "nginx.ingress.kubernetes.io/backend-protocol" = "HTTP"
           }
-          extraTls = [
-            {
-              secretName = "argocd-server-tls"
-              hosts      = ["argocd.canepro.me"]
-            }
-          ]
         }
         resources = {
           limits   = { cpu = "500m", memory = "512Mi" }


### PR DESCRIPTION
## Summary
- remove the redundant Argo CD `server.ingress.extraTls` block so the rendered `argocd-server` Ingress has one TLS entry instead of two identical `argocd.canepro.me` / `argocd-server-tls` entries
- carry forward the Metrics Server 3.13.1 tracking update that PR #99 merged without touching `VERSION-TRACKING.md`

## Evidence
- `monitoring/prometheus-server-6f9856db75-knlxt:prometheus-server` logs show Prometheus starts cleanly, replays WAL, and becomes ready at 2026-06-17T15:20:15Z
- the recurring Prometheus warning is `Error on ingesting samples with different value but same timestamp` from kube-state-metrics target `10.244.0.216:8080`
- direct kube-state-metrics sampling found one duplicate series: `kube_ingress_tls{namespace="argocd",ingress="argocd-server",tls_host="argocd.canepro.me",secret="argocd-server-tls"}`
- live `argocd-server` Ingress has that TLS host/secret twice
- Helm render proof: `server.ingress.tls=true` plus `extraTls` renders two TLS entries; `server.ingress.tls=true` alone renders one

## Verification
- `git diff --check`
- `terraform -chdir=terraform fmt -check -diff`
- `terraform -chdir=terraform validate`
- `helm template argocd argo-cd --repo https://argoproj.github.io/argo-helm --version 9.3.4 ...` produced one `argocd-server` TLS entry
- `helm template metrics-server metrics-server --repo https://kubernetes-sigs.github.io/metrics-server/ --version 3.13.1 --namespace kube-system -f helm/metrics-server-values.yaml` rendered 259 lines

## Post-merge
Apply the Terraform change through the normal reviewed Terraform path before expecting the live Ingress and Prometheus warning to clear. This PR does not live-apply Terraform.